### PR TITLE
Improve non-ok fetch response handling and properly escape "unresolvable" error

### DIFF
--- a/src/TreeToTS/templates/javascript/browser/fetchFunction.ts
+++ b/src/TreeToTS/templates/javascript/browser/fetchFunction.ts
@@ -1,4 +1,16 @@
 export default `
+const handleFetchResponse = response => {
+  if (!response.ok) {
+    return new Promise((resolve, reject) => {
+      response.text().then(text => {
+        try { reject(JSON.parse(text)); }
+        catch (err) { reject(text); }
+      }).catch(reject);
+    });
+  }
+  return response.json();
+};
+
 const apiFetch = (options, query) => {
     const fetchFunction = fetch;
     let queryString = query;
@@ -6,7 +18,7 @@ const apiFetch = (options, query) => {
     if (fetchOptions.method && fetchOptions.method === 'GET') {
       queryString = encodeURIComponent(query);
       return fetchFunction(\`\${options[0]}?query=\${queryString}\`, fetchOptions)
-        .then((response) => response.json())
+        .then(handleFetchResponse)
         .then((response) => {
           if (response.errors) {
             throw new GraphQLError(response);
@@ -23,7 +35,7 @@ const apiFetch = (options, query) => {
       },
       ...fetchOptions
     })
-      .then((response) => response.json())
+      .then(handleFetchResponse)
       .then((response) => {
         if (response.errors) {
           throw new GraphQLError(response);

--- a/src/TreeToTS/templates/javascript/functions.ts
+++ b/src/TreeToTS/templates/javascript/functions.ts
@@ -37,7 +37,7 @@ export const javascriptFunctions = (env: Environment) => `
       resolvedValue = resolvedValue[key];
     }
     if (!resolvedValue) {
-      throw new Error(`Cannot resolve ${type} ${name}${key ? ` ${key}` : ''}`)
+      throw new Error(\`Cannot resolve \${type} \${name}\${key ? \` \${key}\` : ''}\`)
     }
     const typeResolved = resolvedValue.type;
     const isArray = resolvedValue.array;

--- a/src/TreeToTS/templates/javascript/node/fetchFunction.ts
+++ b/src/TreeToTS/templates/javascript/node/fetchFunction.ts
@@ -1,4 +1,16 @@
 export default `
+const handleFetchResponse = response => {
+  if (!response.ok) {
+    return new Promise((resolve, reject) => {
+      response.text().then(text => {
+        try { reject(JSON.parse(text)); }
+        catch (err) { reject(text); }
+      }).catch(reject);
+    });
+  }
+  return response.json();
+};
+
 const apiFetch = (options, query, name) => {
     let fetchFunction;
     let queryString = query;
@@ -15,7 +27,7 @@ const apiFetch = (options, query, name) => {
         throw new Error("Something gone wrong 'querystring' is a part of nodejs environment");
       }
       return fetchFunction(\`\${options[0]}?query=\${queryString}\`, fetchOptions)
-        .then((response) => response.json())
+        .then(handleFetchResponse)
         .then((response) => {
           if (response.errors) {
             throw new GraphQLError(response);
@@ -32,7 +44,7 @@ const apiFetch = (options, query, name) => {
       },
       ...fetchOptions
     })
-      .then((response) => response.json())
+      .then(handleFetchResponse)
       .then((response) => {
         if (response.errors) {
           throw new GraphQLError(response);

--- a/src/TreeToTS/templates/typescript/functions.ts
+++ b/src/TreeToTS/templates/typescript/functions.ts
@@ -44,7 +44,7 @@ export const TypesPropsResolver = ({
     resolvedValue = resolvedValue[key];
   }
   if (!resolvedValue) {
-    throw new Error(`Cannot resolve ${type} ${name}${key ? ` ${key}` : ''}`)
+    throw new Error(\`Cannot resolve \${type} \${name}\${key ? \` \${key}\` : ''}\`)
   }
   const typeResolved = resolvedValue.type;
   const isArray: boolean = resolvedValue.array;

--- a/src/TreeToTS/templates/typescript/node/fetchFunction.ts
+++ b/src/TreeToTS/templates/typescript/node/fetchFunction.ts
@@ -1,4 +1,18 @@
 export default `
+const handleFetchResponse = (
+  response: Parameters<Extract<Parameters<ReturnType<typeof fetch>['then']>[0], Function>>[0]
+): Promise<GraphQLResponse> => {
+  if (!response.ok) {
+    return new Promise((resolve, reject) => {
+      response.text().then(text => {
+        try { reject(JSON.parse(text)); }
+        catch (err) { reject(text); }
+      }).catch(reject);
+    });
+  }
+  return response.json();
+};
+
 const apiFetch = (options: fetchOptions, query: string) => {
     let fetchFunction;
     let queryString = query;
@@ -15,7 +29,7 @@ const apiFetch = (options: fetchOptions, query: string) => {
           throw new Error("Something gone wrong 'querystring' is a part of nodejs environment");
       }
       return fetchFunction(\`\${options[0]}?query=\${queryString}\`, fetchOptions)
-        .then((response: any) => response.json() as Promise<GraphQLResponse>)
+        .then(handleFetchResponse)
         .then((response: GraphQLResponse) => {
           if (response.errors) {
             throw new GraphQLError(response);
@@ -32,7 +46,7 @@ const apiFetch = (options: fetchOptions, query: string) => {
       },
       ...fetchOptions
     })
-      .then((response: any) => response.json() as Promise<GraphQLResponse>)
+      .then(handleFetchResponse)
       .then((response: GraphQLResponse) => {
         if (response.errors) {
           throw new GraphQLError(response);


### PR DESCRIPTION
**2f170768ffe167402ba71829d9f1e5c1910e4bc4**:
Depending on the GraphQL implementation on the backend, it may or may not return a JSON body. While it normally should, if it does not, an error likely may have occurred. In these cases, we should use [`response.ok`](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) as an indicator of something having gone wrong, and graphql-zeus should forward these error response bodies to the client (developer) instead of throwing an error when parsing it as `json()`

---

**6829c80428a8f7eb2ec1dae5d130842990e6c7c4**:
The
```
`Cannot resolve ${type} ${name}${key ? ` ${key}` : ''}`
```
code was not properly escaped in its respective template literal