### PR TITLE
Feat: Enables generation of schema with custom query, mutation and subscription names

### DIFF
--- a/src/TreeToTS/templates/javascript/operations.ts
+++ b/src/TreeToTS/templates/javascript/operations.ts
@@ -1,73 +1,60 @@
-import { ResolvedOperations } from 'TreeToTS';
-import { Environment } from '../../../Models/Environment';
+import { OperationName, ResolvedOperations } from 'TreeToTS';
+import { Environment } from '../../../Models';
 import { graphqlErrorJavascript, javascriptFunctions } from './';
 
-export type Operation = 'Query' | 'Mutation' | 'Subscription';
-
-const generateOperationChainingJavascript = (t: Operation): string =>
+const generateOperationChainingJavascript = (t: OperationName): string =>
   `${t}: (o) =>
-    fullChainConstruct(options)('${t}')(o).then(
+    fullChainConstruct(options)('${t.name}')(o).then(
       (response) => response
     )`;
 
-const generateOperationsChainingJavascipt = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+const generateOperationsChainingJavascipt = ({ query, mutation, subscription }: ResolvedOperations): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateOperationChainingJavascript('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateOperationChainingJavascript(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateOperationChainingJavascript('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateOperationChainingJavascript(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateOperationChainingJavascript('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateOperationChainingJavascript(subscription.operationName));
   }
   return allOps;
 };
 
-const generateOperationZeusJavascript = (t: Operation): string => `${t}: (o) => queryConstruct('${t}')(o)`;
+const generateOperationZeusJavascript = (t: OperationName): string =>
+  `${t.name}: (o) => queryConstruct('${t.name}')(o)`;
 
-const generateOperationsZeusJavascipt = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+const generateOperationsZeusJavascipt = ({ query, mutation, subscription }: ResolvedOperations): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateOperationZeusJavascript('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateOperationZeusJavascript(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateOperationZeusJavascript('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateOperationZeusJavascript(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateOperationZeusJavascript('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateOperationZeusJavascript(subscription.operationName));
   }
   return allOps;
 };
 
-const generateOperationCastJavascript = (t: Operation): string => `${t}: (o) => (b) => o`;
+const generateOperationCastJavascript = (t: OperationName): string => `${t}: (o) => (b) => o`;
 
-const generateOperationsCastJavascipt = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+const generateOperationsCastJavascipt = ({ query, mutation, subscription }: ResolvedOperations): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateOperationCastJavascript('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateOperationCastJavascript(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateOperationCastJavascript('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateOperationCastJavascript(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateOperationCastJavascript('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateOperationCastJavascript(subscription.operationName));
   }
   return allOps;
 };
-export const bodyJavascript = (env: Environment, resolvedOperations: Partial<ResolvedOperations>): string => `
+export const bodyJavascript = (env: Environment, resolvedOperations: ResolvedOperations): string => `
 ${graphqlErrorJavascript}
 ${javascriptFunctions(env)}
 

--- a/src/TreeToTS/templates/javascript/operations.ts
+++ b/src/TreeToTS/templates/javascript/operations.ts
@@ -3,7 +3,7 @@ import { Environment } from '../../../Models';
 import { graphqlErrorJavascript, javascriptFunctions } from './';
 
 const generateOperationChainingJavascript = (t: OperationName): string =>
-  `${t}: (o) =>
+  `${t.name}: (o) =>
     fullChainConstruct(options)('${t.name}')(o).then(
       (response) => response
     )`;
@@ -39,7 +39,7 @@ const generateOperationsZeusJavascipt = ({ query, mutation, subscription }: Reso
   return allOps;
 };
 
-const generateOperationCastJavascript = (t: OperationName): string => `${t}: (o) => (b) => o`;
+const generateOperationCastJavascript = (t: OperationName): string => `${t.name}: (o) => (b) => o`;
 
 const generateOperationsCastJavascipt = ({ query, mutation, subscription }: ResolvedOperations): string[] => {
   const allOps: string[] = [];

--- a/src/TreeToTS/templates/javascript/types.ts
+++ b/src/TreeToTS/templates/javascript/types.ts
@@ -1,68 +1,68 @@
-import { ResolvedOperations } from 'TreeToTS';
+import { OperationName, ResolvedOperations } from 'TreeToTS';
 import { VALUETYPES } from '../resolveValueTypes';
 
 const generateOperationsJavascriptDefinitionsChaining = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+  query,
+  mutation,
+  subscription,
+}: ResolvedOperations): string[] => {
   const allOps = [];
-  if (queries && queries.length) {
-    allOps.push(`Query: OperationToGraphQL<${VALUETYPES}["Query"],Query>`);
+  if (query.operations.length) {
+    allOps.push(`Query: OperationToGraphQL<${VALUETYPES}[query.name],Query>`);
   }
-  if (mutations && mutations.length) {
-    allOps.push(`Mutation: OperationToGraphQL<${VALUETYPES}["Mutation"],Mutation>`);
+  if (mutation.operations.length) {
+    allOps.push(`Mutation: OperationToGraphQL<${VALUETYPES}[mutation.name],Mutation>`);
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(`Subscription: OperationToGraphQL<${VALUETYPES}["Subscription"],Subscription>`);
+  if (subscription.operations.length) {
+    allOps.push(`Subscription: OperationToGraphQL<${VALUETYPES}[subscription.name],Subscription>`);
   }
   return allOps;
 };
 
-const ZeusOperations = (t: string): string => `${t}: (o: ${VALUETYPES}["${t}"]) => string`;
+const ZeusOperations = (t: OperationName): string => `${t.name}: (o: ${VALUETYPES}["${t.name}"]) => string`;
 
 const generateOperationsJavascriptDefinitionsZeus = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+  query,
+  mutation,
+  subscription,
+}: ResolvedOperations): string[] => {
   const allOps = [];
-  if (queries && queries.length) {
-    allOps.push(ZeusOperations('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(ZeusOperations(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(ZeusOperations('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(ZeusOperations(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(ZeusOperations('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(ZeusOperations(subscription.operationName));
   }
   return allOps;
 };
 
-const CastOperations = (t: string): string => `${t}: CastToGraphQL<
-  ValueTypes["${t}"],
-  ${t}
+const CastOperations = (t: OperationName): string => `${t.name}: CastToGraphQL<
+  ValueTypes["${t.name}"],
+  ${t.name}
 >`;
 
 const generateOperationsJavascriptDefinitionsCast = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+  query,
+  mutation,
+  subscription,
+}: ResolvedOperations): string[] => {
   const allOps = [];
-  if (queries && queries.length) {
-    allOps.push(CastOperations('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(CastOperations(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(CastOperations('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(CastOperations(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(CastOperations('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(CastOperations(subscription.operationName));
   }
   return allOps;
 };
 
-export const generateOperationsJavascript = (operationsBody: Partial<ResolvedOperations>): string => `
+export const generateOperationsJavascript = (operationsBody: ResolvedOperations): string => `
 export declare function Chain(
   ...options: fetchOptions
 ):{

--- a/src/TreeToTS/templates/typescript/functions.ts
+++ b/src/TreeToTS/templates/typescript/functions.ts
@@ -1,6 +1,12 @@
-import { Environment } from '../../../Models/Environment';
+import { Environment } from '../../../Models';
+import { OperationName } from '../../index';
 
-export const typescriptFunctions = (env: Environment): string => `
+export const typescriptFunctions = (
+  env: Environment,
+  queryName: OperationName | undefined,
+  mutationName: OperationName | undefined,
+  subscription: OperationName | undefined,
+): string => `
 export const ZeusSelect = <T>() => ((t: any) => t) as SelectionFunction<T>;
 export const ScalarResolver = (scalar: string, value: any) => {
   switch (scalar) {
@@ -156,9 +162,12 @@ const traverseToSeekArrays = (parent: string[], a?: any): string => {
 const buildQuery = (type: string, a?: Record<any, any>) =>
   traverseToSeekArrays([type], a)
 
-const queryConstruct = (t: 'Query' | 'Mutation' | 'Subscription') => (o: Record<any, any>) => \`\${t.toLowerCase()}\${buildQuery(t, o)}\`;
+const queryConstruct = (t: '${queryName?.name || 'Query'}' | '${mutationName?.name ||
+  'Mutation'}' | '${subscription?.name ||
+  'Subscription'}') => (o: Record<any, any>) => \`\${t.toLowerCase()}\${buildQuery(t, o)}\`;
 
-const fullChainConstruct = (options: fetchOptions) => (t: 'Query' | 'Mutation' | 'Subscription') => (o: Record<any, any>) =>
+const fullChainConstruct = (options: fetchOptions) => (t: '${queryName?.name || 'Query'}' | '${mutationName?.name ||
+  'Mutation'}' | '${subscription?.name || 'Subscription'}') => (o: Record<any, any>) =>
   apiFetch(options, queryConstruct(t)(o));
 
 const seekForAliases = (o: any) => {

--- a/src/TreeToTS/templates/typescript/operations.ts
+++ b/src/TreeToTS/templates/typescript/operations.ts
@@ -1,97 +1,90 @@
 import { Environment } from 'Models/Environment';
-import { ResolvedOperations } from 'TreeToTS';
-import { Operation } from '../javascript';
+import { OperationName, ResolvedOperations } from 'TreeToTS';
 import { VALUETYPES } from '../resolveValueTypes';
 import { constantTypesTypescript, graphqlErrorTypeScript, typescriptFunctions } from './';
 
-const generateOperationChaining = (t: Operation): string =>
-  `${t}: ((o: any) =>
-    fullChainConstruct(options)('${t}')(o).then(
+const generateOperationChaining = (t: OperationName): string =>
+  `${t.name}: ((o: any) =>
+    fullChainConstruct(options)('${t.name}')(o).then(
       (response: any) => response
-    )) as OperationToGraphQL<${VALUETYPES}["${t}"],${t}>`;
+    )) as OperationToGraphQL<${VALUETYPES}["${t.name}"],${t.name}>`;
 
-const generateOperationsChaining = ({ queries, mutations, subscriptions }: Partial<ResolvedOperations>): string[] => {
+const generateOperationsChaining = ({ query, mutation, subscription }: Partial<ResolvedOperations>): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateOperationChaining('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateOperationChaining(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateOperationChaining('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateOperationChaining(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateOperationChaining('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateOperationChaining(subscription.operationName));
   }
   return allOps;
 };
 
-const generateOperationZeus = (t: Operation): string => `${t}: (o:${VALUETYPES}["${t}"]) => queryConstruct('${t}')(o)`;
+const generateOperationZeus = (t: OperationName): string =>
+  `${t.name}: (o:${VALUETYPES}["${t.name}"]) => queryConstruct('${t.name}')(o)`;
 
-const generateOperationsZeusTypeScript = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+const generateOperationsZeusTypeScript = ({ query, mutation, subscription }: Partial<ResolvedOperations>): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateOperationZeus('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateOperationZeus(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateOperationZeus('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateOperationZeus(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateOperationZeus('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateOperationZeus(subscription.operationName));
   }
   return allOps;
 };
 
-const generateSelectorZeus = (t: Operation): string => `${t}: ZeusSelect<${VALUETYPES}["${t}"]>()`;
+const generateSelectorZeus = (t: OperationName): string => `${t.name}: ZeusSelect<${VALUETYPES}["${t.name}"]>()`;
 
-const generateSelectorsZeusTypeScript = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+const generateSelectorsZeusTypeScript = ({ query, mutation, subscription }: Partial<ResolvedOperations>): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateSelectorZeus('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateSelectorZeus(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateSelectorZeus('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateSelectorZeus(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateSelectorZeus('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateSelectorZeus(subscription.operationName));
   }
   return allOps;
 };
 
-const generateOperationCast = (t: Operation): string =>
-  `${t}: ((o: any) => (b: any) => o) as CastToGraphQL<
-  ValueTypes["${t}"],
-  ${t}
+const generateOperationCast = (t: OperationName): string =>
+  `${t.name}: ((o: any) => (b: any) => o) as CastToGraphQL<
+  ValueTypes["${t.name}"],
+  ${t.name}
 >`;
 
-const generateOperationsCastTypeScript = ({
-  queries,
-  mutations,
-  subscriptions,
-}: Partial<ResolvedOperations>): string[] => {
+const generateOperationsCastTypeScript = ({ query, mutation, subscription }: Partial<ResolvedOperations>): string[] => {
   const allOps: string[] = [];
-  if (queries && queries.length) {
-    allOps.push(generateOperationCast('Query'));
+  if (query?.operationName?.name && query.operations.length) {
+    allOps.push(generateOperationCast(query.operationName));
   }
-  if (mutations && mutations.length) {
-    allOps.push(generateOperationCast('Mutation'));
+  if (mutation?.operationName?.name && mutation.operations.length) {
+    allOps.push(generateOperationCast(mutation.operationName));
   }
-  if (subscriptions && subscriptions.length) {
-    allOps.push(generateOperationCast('Subscription'));
+  if (subscription?.operationName?.name && subscription.operations.length) {
+    allOps.push(generateOperationCast(subscription.operationName));
   }
   return allOps;
 };
 
-export const bodyTypeScript = (env: Environment, resolvedOperations: Partial<ResolvedOperations>): string => `
+export const bodyTypeScript = (env: Environment, resolvedOperations: ResolvedOperations): string => `
 ${graphqlErrorTypeScript}
 ${constantTypesTypescript}
-${typescriptFunctions(env)}
+${typescriptFunctions(
+  env,
+  resolvedOperations.query.operationName,
+  resolvedOperations.mutation.operationName,
+  resolvedOperations.subscription.operationName,
+)}
 
 export const Chain = (...options: fetchOptions) => ({
   ${generateOperationsChaining(resolvedOperations).join(',\n')}

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -33,18 +33,23 @@ export class Utils {
     const c = buildClientSchema(data);
     const { queryType, mutationType, subscriptionType } = (data as IntrospectionQuery).__schema;
     let schemaClient = printSchema(c);
-    const addons = [];
-    if (queryType) {
-      addons.push(`query: ${queryType.name}`);
-    }
-    if (mutationType) {
-      addons.push(`mutation: ${mutationType.name}`);
-    }
-    if (subscriptionType) {
-      addons.push(`subscription: ${subscriptionType.name}`);
-    }
-    if (addons.length > 0) {
-      schemaClient += `\nschema{\n\t${addons.join(',\n\t')}\n}`;
+    const isSchemaOfCommonNames =
+      queryType?.name === 'Query' || mutationType?.name === 'Mutation' || subscriptionType?.name === 'Subscription';
+
+    if (isSchemaOfCommonNames) {
+      const addons = [];
+      if (queryType) {
+        addons.push(`query: ${queryType.name}`);
+      }
+      if (mutationType) {
+        addons.push(`mutation: ${mutationType.name}`);
+      }
+      if (subscriptionType) {
+        addons.push(`subscription: ${subscriptionType.name}`);
+      }
+      if (addons.length > 0) {
+        schemaClient += `\nschema{\n\t${addons.join(',\n\t')}\n}`;
+      }
     }
     return schemaClient;
   };

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -34,7 +34,7 @@ export class Utils {
     const { queryType, mutationType, subscriptionType } = (data as IntrospectionQuery).__schema;
     let schemaClient = printSchema(c);
     const isSchemaOfCommonNames =
-      queryType?.name === 'Query' || mutationType?.name === 'Mutation' || subscriptionType?.name === 'Subscription';
+      queryType?.name === 'Query' && mutationType?.name === 'Mutation' && subscriptionType?.name === 'Subscription';
 
     if (isSchemaOfCommonNames) {
       const addons = [];


### PR DESCRIPTION
**Issue:**

[125: Root queries with names other than Query produce error: "Cannot read property 'getQueryType' of undefined](https://github.com/graphql-editor/graphql-zeus/issues/125)

**Cause:**

The graphql-js [schemaPrinter](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js) adds the schema definition to the schema file if the schema uses a non-common name such as `Foo` for the Query, Mutation, or Subscription name . 

Refer to the following functions in graphql-js:

- [printFilteredSchema](https://github.com/graphql/graphql-js/blob/8c7fe9de3f1412b49faa85aab4c626d11e399806/src/utilities/schemaPrinter.js#L81)
- [printSchemaDefinition](https://github.com/graphql/graphql-js/blob/8c7fe9de3f1412b49faa85aab4c626d11e399806/src/utilities/schemaPrinter.js#L104)
- [isSchemaOfCommonNames](https://github.com/graphql/graphql-js/blob/8c7fe9de3f1412b49faa85aab4c626d11e399806/src/utilities/schemaPrinter.js#L141)

Graphql-zeus currently appends a duplicate schema entry in the returned schema file for queries with non-common names which in turn causes code generation to fail.

**Fix:**

This commit adds a conditional test which determines if the schema uses common names and uses it to only execute the add on logic if required.