### PR TITLE
Fix missing .response on the JS version of GraphQLError

### DIFF
--- a/src/TreeToTS/templates/javascript/error.ts
+++ b/src/TreeToTS/templates/javascript/error.ts
@@ -2,6 +2,7 @@ export const graphqlErrorJavascript = `
 export class GraphQLError extends Error {
     constructor(response) {
       super("");
+      this.response = response;
       console.error(response);
     }
     toString() {


### PR DESCRIPTION
The TypeScript version of GraphQLError has the response property set [here](https://github.com/graphql-editor/graphql-zeus/blob/f3716175af558160922cb4dd6b3151acb9016b00/src/TreeToTS/templates/typescript/error.ts#L3) but was missing on the JavaScript version.