### PR TITLE
Fix TypeScript intellisense and type checking when query is different with generated types

### DIFF
--- a/src/TreeToTS/templates/typescript/types.ts
+++ b/src/TreeToTS/templates/typescript/types.ts
@@ -107,11 +107,11 @@ type MapType<SRC extends Anify<DST>, DST> = DST extends boolean
         : LastMapTypeSRCResolver<SRC[Key], DST[Key]>;
     };
 
-type OperationToGraphQL<V, T> = <Z>(o: Z | V, variables?: Record<string, any>) => Promise<MapType<T, Z>>;
+type OperationToGraphQL<V, T> = <Z extends V>(o: Z | V, variables?: Record<string, any>) => Promise<MapType<T, Z>>;
 
 type CastToGraphQL<V, T> = (
   resultOfYourQuery: any
-) => <Z>(o: Z | V) => MapType<T, Z>;
+) => <Z extends V>(o: Z | V) => MapType<T, Z>;
 
 type fetchOptions = ArgsType<typeof fetch>;
 


### PR DESCRIPTION
According to the way Generic works in TypeScript, even if the type of the `OperationToGraphQL` function Argument is different from `Z`, no type error is output.  This turns Intellisense into a cradle and adversely affects the development experience. To fix this, I added the `extends` syntax in `OperationToGraphQL`.

### Before

<img width="1528" alt="스크린샷 2020-03-15 오후 4 10 49" src="https://user-images.githubusercontent.com/20325202/76697205-a9bda000-66d7-11ea-8500-bd0f1bdb2086.png">

`./examples/typescript-node:9`
```typescript
const { addCard: ZeusCard } = await Gql.mutation({
  addCard: [
    {
      card: {
        AttackThisIsError: 1, // No error even if given query is wrong
        Defense: 2,
        description: '$myVar',
        name: 'SADSD',
        skills: [SpecialSkills.FIRE],
      },
    },
    {
      id: true,
      description: true,
      name: true,
      Attack: true,
      skills: true,
      Children: true,
      Defense: true,
      cardImage: {
        bucket: true,
        region: true,
        key: true,
      },
    },
  ],
});
```
### After
> Type(`graphql-zeus.ts`) is generated with `/lib/CLI/index.ts`

<img width="1528" alt="스크린샷 2020-03-15 오후 4 11 22" src="https://user-images.githubusercontent.com/20325202/76697207-b2ae7180-66d7-11ea-985e-b42d885ec073.png">

```typescript
const { addCard: ZeusCard } = await Gql.mutation({
  addCard: [
    {
      card: {
        AttackThisIsError: 1, // Error!
        Defense: 2,
        description: '$myVar',
        name: 'SADSD',
        skills: [SpecialSkills.FIRE],
      },
    },
    {
      id: true,
      description: true,
      name: true,
      Attack: true,
      skills: true,
      Children: true,
      Defense: true,
      cardImage: {
        bucket: true,
        region: true,
        key: true,
      },
    },
  ],
});
```
And also my Intellisense problem in VS Code is fixed.