### PR TITLE
Better Interface Support

### DIFF
--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -37,17 +37,7 @@ describe('Interface tests', () => {
 
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
-      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: ValueTypes["Car"]; ['...on Motorcycle']?: ValueTypes["Motorcycle"]; __typename?: true }>;`,
-    );
-
-    // since wheels already exists on vehicle and is common, should not be on subtypes
-    expect(typeScriptCode).toContain(`["Car"]: AliasType<{color?:true __typename?: true }>`);
-    expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{visor?:true __typename?: true }>`);
-
-    // however we still want them to be copied over to the standard types
-    expect(typeScriptCode).toContain(`export type Car = {__typename?: "Car",wheels?:number,color?:string }`);
-    expect(typeScriptCode).toContain(
-      `export type Motorcycle = {__typename?: "Motorcycle",wheels?:number,visor?:boolean }`
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],ValueTypes["Vehicle"]>; __typename?: true }>;`,
     );
   });
 
@@ -57,17 +47,7 @@ describe('Interface tests', () => {
 
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
-      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: ValueTypes["Car"]; ['...on Motorcycle']?: ValueTypes["Motorcycle"]; __typename?: true }>;`,
-    );
-
-    // since wheels already exists on vehicle and is common, should not be on subtypes
-    expect(typeScriptCode).toContain(`["Car"]: AliasType<{ __typename?: true }>`);
-    expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{ __typename?: true }>`);
-
-    // however we still want them to be copied over to the standard types
-    expect(typeScriptCode).toContain(`export type Car = {__typename?: "Car",wheels?:number }`);
-    expect(typeScriptCode).toContain(
-      `export type Motorcycle = {__typename?: "Motorcycle",wheels?:number }`
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],ValueTypes["Vehicle"]>; __typename?: true }>;`,
     );
   });
 

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -1,0 +1,34 @@
+import { Parser } from '../../src/Parser';
+import { TreeToTS } from '../../src/TreeToTS';
+
+const schema = `
+interface Vehicle {
+  wheels: Int
+}
+
+type Car implements Vehicle {
+  wheels: Int
+  color: String
+}
+
+type Motorcycle implements Vehicle {
+  wheels: Int
+  visor: Boolean
+}
+`;
+describe('Interface tests', () => {
+  it('TypeScript: Selectors', () => {
+    const tree = Parser.parseAddExtensions(schema);
+    const typeScriptCode = TreeToTS.resolveTree(tree).replace(/\n\t/g, '').replace(/\s/g, ' ');
+
+    // should have wheels as a field on vehicle
+    expect(typeScriptCode).toContain(
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']: ValueTypes["Car"]; ['...on Motorcycle']: ValueTypes["Motorcycle"]; __typename?: true }>;`,
+    );
+
+    // since wheels already exists on vehicle and is common, should not be on subtypes
+    expect(typeScriptCode).toContain(`["Car"]: AliasType<{color?:true __typename?: true }>`);
+    expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{visor?:true __typename?: true }>`);
+  });
+
+});

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -1,7 +1,7 @@
 import { Parser } from '../../src/Parser';
 import { TreeToTS } from '../../src/TreeToTS';
 
-const schema = `
+const schemaWithUnique = `
 interface Vehicle {
   wheels: Int
 }
@@ -16,9 +16,23 @@ type Motorcycle implements Vehicle {
   visor: Boolean
 }
 `;
+
+const schema = `
+interface Vehicle {
+  wheels: Int
+}
+
+type Car implements Vehicle {
+  wheels: Int
+}
+
+type Motorcycle implements Vehicle {
+  wheels: Int
+}
+`;
 describe('Interface tests', () => {
-  it('TypeScript: Selectors', () => {
-    const tree = Parser.parseAddExtensions(schema);
+  it('TypeScript: Interfaces with Unique Fields', () => {
+    const tree = Parser.parseAddExtensions(schemaWithUnique);
     const typeScriptCode = TreeToTS.resolveTree(tree).replace(/\n\t/g, '').replace(/\s/g, ' ');
 
     // should have wheels as a field on vehicle
@@ -29,6 +43,20 @@ describe('Interface tests', () => {
     // since wheels already exists on vehicle and is common, should not be on subtypes
     expect(typeScriptCode).toContain(`["Car"]: AliasType<{color?:true __typename?: true }>`);
     expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{visor?:true __typename?: true }>`);
+  });
+
+  it('TypeScript: Interfaces without Unique Fields', () => {
+    const tree = Parser.parseAddExtensions(schema);
+    const typeScriptCode = TreeToTS.resolveTree(tree).replace(/\n\t/g, '').replace(/\s/g, ' ');
+
+    // should have wheels as a field on vehicle
+    expect(typeScriptCode).toContain(
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']: ValueTypes["Car"]; ['...on Motorcycle']: ValueTypes["Motorcycle"]; __typename?: true }>;`,
+    );
+
+    // since wheels already exists on vehicle and is common, should not be on subtypes
+    expect(typeScriptCode).toContain(`["Car"]: AliasType<{ __typename?: true }>`);
+    expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{ __typename?: true }>`);
   });
 
 });

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -37,7 +37,7 @@ describe('Interface tests', () => {
 
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
-      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],ValueTypes["Vehicle"]>; __typename?: true }>;`,
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],keyof ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],keyof ValueTypes["Vehicle"]>; __typename?: true }>;`,
     );
   });
 
@@ -47,7 +47,7 @@ describe('Interface tests', () => {
 
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
-      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],ValueTypes["Vehicle"]>; __typename?: true }>;`,
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],keyof ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],keyof ValueTypes["Vehicle"]>; __typename?: true }>;`,
     );
   });
 

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -39,6 +39,16 @@ describe('Interface tests', () => {
     expect(typeScriptCode).toContain(
       `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],keyof ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],keyof ValueTypes["Vehicle"]>; __typename?: true }>;`,
     );
+
+    // since wheels already exists on vehicle and is common, should not be on subtypes
+    expect(typeScriptCode).toContain(`["Car"]: AliasType<{wheels?:true,color?:true, __typename?: true }>`);
+    expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{wheels?:true,visor?:true, __typename?: true }>`);
+
+    // full type should have all the fields
+    expect(typeScriptCode).toContain(`export type Car = {__typename?: "Car",wheels?:number,color?:string }`);
+    expect(typeScriptCode).toContain(
+      `export type Motorcycle = {__typename?: "Motorcycle",wheels?:number,visor?:boolean }`
+    );
   });
 
   it('TypeScript: Interfaces without Unique Fields', () => {
@@ -48,6 +58,16 @@ describe('Interface tests', () => {
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
       `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: Omit<ValueTypes["Car"],keyof ValueTypes["Vehicle"]>; ['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"],keyof ValueTypes["Vehicle"]>; __typename?: true }>;`,
+    );
+
+    // should support an empty subtype
+    expect(typeScriptCode).toContain(`["Car"]: AliasType<{wheels?:true, __typename?: true }>`);
+    expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{wheels?:true, __typename?: true }>`);
+
+    // full type should have all the fields
+    expect(typeScriptCode).toContain(`export type Car = {__typename?: "Car",wheels?:number }`);
+    expect(typeScriptCode).toContain(
+      `export type Motorcycle = {__typename?: "Motorcycle",wheels?:number }`
     );
   });
 

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -29,10 +29,6 @@ type Car implements Vehicle {
 type Motorcycle implements Vehicle {
   wheels: Int
 }
-
-type Garage {
-  vehicles: [Vehicle!]!
-}
 `;
 describe('Interface tests', () => {
   it('TypeScript: Interfaces with Unique Fields', () => {

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -43,6 +43,12 @@ describe('Interface tests', () => {
     // since wheels already exists on vehicle and is common, should not be on subtypes
     expect(typeScriptCode).toContain(`["Car"]: AliasType<{color?:true __typename?: true }>`);
     expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{visor?:true __typename?: true }>`);
+
+    // however we still want them to be copied over to the standard types
+    expect(typeScriptCode).toContain(`export type Car = {__typename?: "Car",wheels?:number,color?:string }`);
+    expect(typeScriptCode).toContain(
+      `export type Motorcycle = {__typename?: "Motorcycle",wheels?:number,visor?:boolean }`
+    );
   });
 
   it('TypeScript: Interfaces without Unique Fields', () => {
@@ -57,6 +63,12 @@ describe('Interface tests', () => {
     // since wheels already exists on vehicle and is common, should not be on subtypes
     expect(typeScriptCode).toContain(`["Car"]: AliasType<{ __typename?: true }>`);
     expect(typeScriptCode).toContain(`["Motorcycle"]: AliasType<{ __typename?: true }>`);
+
+    // however we still want them to be copied over to the standard types
+    expect(typeScriptCode).toContain(`export type Car = {__typename?: "Car",wheels?:number }`);
+    expect(typeScriptCode).toContain(
+      `export type Motorcycle = {__typename?: "Motorcycle",wheels?:number }`
+    );
   });
 
 });

--- a/__tests__/TreeToTS/Interface.spec.ts
+++ b/__tests__/TreeToTS/Interface.spec.ts
@@ -29,6 +29,10 @@ type Car implements Vehicle {
 type Motorcycle implements Vehicle {
   wheels: Int
 }
+
+type Garage {
+  vehicles: [Vehicle!]!
+}
 `;
 describe('Interface tests', () => {
   it('TypeScript: Interfaces with Unique Fields', () => {
@@ -37,7 +41,7 @@ describe('Interface tests', () => {
 
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
-      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']: ValueTypes["Car"]; ['...on Motorcycle']: ValueTypes["Motorcycle"]; __typename?: true }>;`,
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: ValueTypes["Car"]; ['...on Motorcycle']?: ValueTypes["Motorcycle"]; __typename?: true }>;`,
     );
 
     // since wheels already exists on vehicle and is common, should not be on subtypes
@@ -57,7 +61,7 @@ describe('Interface tests', () => {
 
     // should have wheels as a field on vehicle
     expect(typeScriptCode).toContain(
-      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']: ValueTypes["Car"]; ['...on Motorcycle']: ValueTypes["Motorcycle"]; __typename?: true }>;`,
+      `["Vehicle"]:AliasType<{ wheels?:true; ['...on Car']?: ValueTypes["Car"]; ['...on Motorcycle']?: ValueTypes["Motorcycle"]; __typename?: true }>;`,
     );
 
     // since wheels already exists on vehicle and is common, should not be on subtypes

--- a/src/Parser/typeResolver.ts
+++ b/src/Parser/typeResolver.ts
@@ -1,5 +1,5 @@
 import {
-  ArgumentNode,
+  ArgumentNode, DefinitionNode,
   DirectiveNode,
   FieldDefinitionNode,
   InputValueDefinitionNode,
@@ -47,6 +47,7 @@ export class TypeResolver {
       name: n.name.value,
     };
   }
+
   /**
    * Iterate fields and return them as ParserFields
    *
@@ -67,6 +68,7 @@ export class TypeResolver {
         } as ParserField),
     );
   }
+
   /**
    * Resolve default ValueNode options
    *
@@ -79,6 +81,7 @@ export class TypeResolver {
     }
     return options;
   };
+
   /**
    * Resolve object field
    *
@@ -99,6 +102,7 @@ export class TypeResolver {
       },
     ];
   }
+
   /**
    * Resolve GraphQL ValueNode
    *
@@ -150,6 +154,7 @@ export class TypeResolver {
     }
     return [];
   }
+
   /**
    * Iterate directives
    * @param directives GraphQL Directive nodes
@@ -169,6 +174,7 @@ export class TypeResolver {
         } as ParserField),
     );
   }
+
   /**
    * Iterate argument fields
    *
@@ -191,6 +197,7 @@ export class TypeResolver {
         } as ParserField),
     );
   }
+
   /**
    * Iterate fields of input
    *
@@ -211,6 +218,7 @@ export class TypeResolver {
         } as ParserField),
     );
   }
+
   /**
    * Resolve interfaces on Object Type
    *
@@ -222,6 +230,7 @@ export class TypeResolver {
     }
     return n.interfaces.map((i) => i.name.value);
   }
+
   /**
    * Resolve fields of Type Defintiion node
    *
@@ -276,7 +285,11 @@ export class TypeResolver {
     const fields = TypeResolver.iterateObjectTypeFields(n.fields);
     return fields;
   }
-  static resolveFieldsFromDefinition(n: TypeSystemDefinitionNode | TypeSystemExtensionNode): ParserField[] | undefined {
+
+  static resolveFieldsFromDefinition(
+    n: TypeSystemDefinitionNode | TypeSystemExtensionNode,
+    nodes: readonly DefinitionNode[],
+  ): ParserField[] | undefined {
     if ('values' in n && n.values) {
       return n.values.map(
         (v) =>
@@ -318,7 +331,28 @@ export class TypeResolver {
       if (!n.fields) {
         throw new Error('Type object should have fields');
       }
-      return TypeResolver.iterateObjectTypeFields(n.fields);
+
+      let fields = TypeResolver.iterateObjectTypeFields(n.fields);
+
+      if (n.kind === 'ObjectTypeDefinition' || n.kind === 'ObjectTypeExtension') {
+        const interfaces = (n.interfaces || []).map((i) => {
+          return nodes.find((n) => n.kind === 'InterfaceTypeDefinition' && n.name.value === i.name.value);
+        });
+
+        if (interfaces.length) {
+          fields = fields.filter((field) => {
+            const isInterfaceField = interfaces.some((i) => {
+              const ifields = (i && i.kind === 'InterfaceTypeDefinition' && i.fields) || [];
+
+              return ifields.some((f) => f.name.value === field.name);
+            });
+
+            return !isInterfaceField;
+          });
+        }
+      }
+
+      return fields;
     }
   }
 }

--- a/src/Parser/typeResolver.ts
+++ b/src/Parser/typeResolver.ts
@@ -1,5 +1,6 @@
 import {
-  ArgumentNode, DefinitionNode,
+  ArgumentNode,
+  DefinitionNode,
   DirectiveNode,
   FieldDefinitionNode,
   InputValueDefinitionNode,

--- a/src/Parser/typeResolver.ts
+++ b/src/Parser/typeResolver.ts
@@ -1,6 +1,5 @@
 import {
   ArgumentNode,
-  DefinitionNode,
   DirectiveNode,
   FieldDefinitionNode,
   InputValueDefinitionNode,
@@ -287,10 +286,7 @@ export class TypeResolver {
     return fields;
   }
 
-  static resolveFieldsFromDefinition(
-    n: TypeSystemDefinitionNode | TypeSystemExtensionNode,
-    nodes: readonly DefinitionNode[],
-  ): ParserField[] | undefined {
+  static resolveFieldsFromDefinition(n: TypeSystemDefinitionNode | TypeSystemExtensionNode): ParserField[] | undefined {
     if ('values' in n && n.values) {
       return n.values.map(
         (v) =>
@@ -333,27 +329,7 @@ export class TypeResolver {
         throw new Error('Type object should have fields');
       }
 
-      let fields = TypeResolver.iterateObjectTypeFields(n.fields);
-
-      if (n.kind === 'ObjectTypeDefinition' || n.kind === 'ObjectTypeExtension') {
-        const interfaces = (n.interfaces || []).map((i) => {
-          return nodes.find((n) => n.kind === 'InterfaceTypeDefinition' && n.name.value === i.name.value);
-        });
-
-        if (interfaces.length) {
-          fields = fields.filter((field) => {
-            const isInterfaceField = interfaces.some((i) => {
-              const ifields = (i && i.kind === 'InterfaceTypeDefinition' && i.fields) || [];
-
-              return ifields.some((f) => f.name.value === field.name);
-            });
-
-            return !isInterfaceField;
-          });
-        }
-      }
-
-      return fields;
+      return TypeResolver.iterateObjectTypeFields(n.fields);
     }
   }
 }

--- a/src/TreeToTS/templates/resolveValueTypes.ts
+++ b/src/TreeToTS/templates/resolveValueTypes.ts
@@ -68,7 +68,12 @@ const resolveValueTypeFromRoot = (i: ParserField, rootNodes: ParserField[], enum
     return '';
   }
   if (!i.args || !i.args.length) {
-    return `${plusDescription(i.description)}["${i.name}"]:unknown`;
+    if (!i.interfaces || !i.interfaces.length) {
+      return `${plusDescription(i.description)}["${i.name}"]:unknown`;
+    }
+
+    // if an object implements an interface but has no unique fields
+    return `${plusDescription(i.description)}["${i.name}"]: ${AliasType(`{\n\t\t__typename?: true\n}`)}`;
   }
   if (i.data.type === TypeDefinition.UnionTypeDefinition) {
     return `${plusDescription(i.description)}["${i.name}"]: ${AliasType(

--- a/src/TreeToTS/templates/resolveValueTypes.ts
+++ b/src/TreeToTS/templates/resolveValueTypes.ts
@@ -114,7 +114,7 @@ const resolveValueTypeFromRoot = (i: ParserField, rootNodes: ParserField[], enum
     return `${plusDescription(i.description)}["${i.name}"]:${AliasType(
       `{
 \t${args.map((f) => resolveField(f, enumsAndScalars)).join(',\n')};\n\t\t${typesImplementing
-        .map((f) => `['...on ${f.name}']: ${resolveValueType(f.name)};`)
+        .map((f) => `['...on ${f.name}']?: ${resolveValueType(f.name)};`)
         .join('\n\t\t')}\n\t\t__typename?: true\n}`,
     )}`;
   }

--- a/src/TreeToTS/templates/resolveValueTypes.ts
+++ b/src/TreeToTS/templates/resolveValueTypes.ts
@@ -94,7 +94,7 @@ const resolveValueTypeFromRoot = (i: ParserField, rootNodes: ParserField[], enum
     return `${plusDescription(i.description)}["${i.name}"]:${AliasType(
       `{
 \t${i.args.map((f) => resolveField(f, enumsAndScalars)).join(',\n')};\n\t\t${typesImplementing
-        .map((f) => `['...on ${f.name}']?: Omit<${resolveValueType(f.name)},${resolveValueType(i.name)}>;`)
+        .map((f) => `['...on ${f.name}']?: Omit<${resolveValueType(f.name)},keyof ${resolveValueType(i.name)}>;`)
         .join('\n\t\t')}\n\t\t__typename?: true\n}`,
     )}`;
   }

--- a/src/TreeToTS/templates/resolveValueTypes.ts
+++ b/src/TreeToTS/templates/resolveValueTypes.ts
@@ -69,12 +69,7 @@ const resolveValueTypeFromRoot = (i: ParserField, rootNodes: ParserField[], enum
   }
 
   if (!i.args || !i.args.length) {
-    if (!i.interfaces || !i.interfaces.length) {
-      return `${plusDescription(i.description)}["${i.name}"]:unknown`;
-    }
-
-    // if an object implements an interface but has no unique fields
-    return `${plusDescription(i.description)}["${i.name}"]: ${AliasType(`{\n\t\t__typename?: true\n}`)}`;
+    return `${plusDescription(i.description)}["${i.name}"]:unknown`;
   }
   if (i.data.type === TypeDefinition.UnionTypeDefinition) {
     return `${plusDescription(i.description)}["${i.name}"]: ${AliasType(
@@ -99,7 +94,7 @@ const resolveValueTypeFromRoot = (i: ParserField, rootNodes: ParserField[], enum
     )}`;
   }
   return `${plusDescription(i.description)}["${i.name}"]: ${AliasType(
-    `{\n${i.args.map((f) => resolveField(f, enumsAndScalars)).join(',\n')}\n\t\t__typename?: true\n}`,
+    `{\n${i.args.map((f) => resolveField(f, enumsAndScalars)).join(',\n')},\n\t\t__typename?: true\n}`,
   )}`;
 };
 export const resolveValueTypes = (rootNodes: ParserField[]): string => {

--- a/src/TreeToTS/templates/typescript/types.ts
+++ b/src/TreeToTS/templates/typescript/types.ts
@@ -26,7 +26,8 @@ export type MapInterface<SRC, DST> = SRC extends {
   __interface: infer INTERFACE;
   __resolve: infer IMPLEMENTORS;
 }
-  ? [Key in keyof DST]: Key extends keyof INTERFACE ? INTERFACE[Key] : ObjectToUnion<
+  ? [Key in keyof DST]: Key extends keyof INTERFACE ? INTERFACE[Key] :
+    Key extends keyof IMPLEMENTORS ? ObjectToUnion<
       Omit<
         {
           [Key in keyof Omit<DST, keyof INTERFACE | '__typename'>]: Key extends keyof IMPLEMENTORS
@@ -49,7 +50,7 @@ export type MapInterface<SRC, DST> = SRC extends {
         },
         keyof INTERFACE | '__typename'
       >
-    >
+    > : never
   : never;
 
 export type ValueToUnion<T> = T extends {

--- a/src/TreeToTS/templates/typescript/types.ts
+++ b/src/TreeToTS/templates/typescript/types.ts
@@ -23,35 +23,35 @@ interface GraphQLResponse {
   }>;
 }
 export type MapInterface<SRC, DST> = SRC extends {
-  __interface: infer INTERFACE;
-  __resolve: infer IMPLEMENTORS;
-}
-  ? [Key in keyof DST]: Key extends keyof INTERFACE ? INTERFACE[Key] :
-    Key extends keyof IMPLEMENTORS ? ObjectToUnion<
-      Omit<
-        {
-          [Key in keyof Omit<DST, keyof INTERFACE | '__typename'>]: Key extends keyof IMPLEMENTORS
+    __interface: infer INTERFACE;
+    __resolve: infer IMPLEMENTORS;
+  }
+  ? { [Key in keyof DST]: Key extends keyof INTERFACE ? INTERFACE[Key] :
+      Key extends keyof IMPLEMENTORS ? ObjectToUnion<
+        Omit<
+          {
+            [Key in keyof Omit<DST, keyof INTERFACE | '__typename'>]: Key extends keyof IMPLEMENTORS
             ? MapType<IMPLEMENTORS[Key], DST[Key]> &
-                Omit<
-                  {
-                    [Key in keyof Omit<
-                      DST,
-                      keyof IMPLEMENTORS | '__typename'
-                    >]: Key extends keyof INTERFACE
-                      ? LastMapTypeSRCResolver<INTERFACE[Key], DST[Key]>
-                      : never;
-                  },
-                  keyof IMPLEMENTORS
-                > &
-                (DST extends { __typename: any }
-                  ? MapType<IMPLEMENTORS[Key], { __typename: true }>
-                  : {})
+            Omit<
+              {
+                [Key in keyof Omit<
+                DST,
+                keyof IMPLEMENTORS | '__typename'
+                >]: Key extends keyof INTERFACE
+                ? LastMapTypeSRCResolver<INTERFACE[Key], DST[Key]>
+                : never;
+              },
+              keyof IMPLEMENTORS
+              > &
+            (DST extends { __typename: any }
+              ? MapType<IMPLEMENTORS[Key], { __typename: true }>
+              : {})
             : never;
-        },
-        keyof INTERFACE | '__typename'
-      >
-    > : never
-  : never;
+          },
+          keyof INTERFACE | '__typename'
+          >
+        > : never
+  } : never;
 
 export type ValueToUnion<T> = T extends {
   __typename: infer R;

--- a/src/TreeToTS/templates/typescript/types.ts
+++ b/src/TreeToTS/templates/typescript/types.ts
@@ -26,7 +26,7 @@ export type MapInterface<SRC, DST> = SRC extends {
   __interface: infer INTERFACE;
   __resolve: infer IMPLEMENTORS;
 }
-  ? ObjectToUnion<
+  ? [Key in keyof DST]: Key extends keyof INTERFACE ? INTERFACE[Key] : ObjectToUnion<
       Omit<
         {
           [Key in keyof Omit<DST, keyof INTERFACE | '__typename'>]: Key extends keyof IMPLEMENTORS


### PR DESCRIPTION
This PR fixes some compile time issues with the interface type generation in typescript.

Given an example schema:

```graphql
interface Vehicle {
  wheels: Int
}

type Car implements Vehicle {
  wheels: Int
  color: String
}

type Motorcycle implements Vehicle {
  wheels: Int
  visor: Boolean
}

type Garage {
  vehicles: [Vehicle!]!
}
```

### Optional Subtyping

Without this PR, the below is not possible. The typing should not require the user to provide ['...on Subtype'], fixed by adding `?` to the type and also updating `MapInterface` to look for keys in the interface vs. before implementations: `[Key in keyof DST]: Key extends keyof INTERFACE ? INTERFACE[Key] :
      Key extends keyof IMPLEMENTORS ? ObjectToUnion....`

```typescript
const Data = Selectors.query({
  garage: [
    { id: '1' },
    {
      id: true,
      vehicles: {
        wheels: true
      },
    },
  ],
});
```
Before

```typescript
type ValueTypes = {
	["Car"]: AliasType<{
		wheels?:true;
		color?: String;
	}>,
	["Vehicle"]:AliasType<{
		id?:true,
		wheels?:true;
		['...on Motorcycle']: ValueTypes["Motorcycle"];
		['...on Car']: ValueTypes["Car"];
	}
}
```
After
```typescript
type ValueTypes = {
	["Car"]: AliasType<{
                 wheels?:true;
		color?: String;
	}>,
	["Vehicle"]:AliasType<{
		id?:true,
		wheels?:true;
		['...on Motorcycle']?: Omit<ValueTypes["Motorcycle"], keyof ValueTypes["Vehicle"]>;
		['...on Car']?: Omit<ValueTypes["Car"], keyof ValueTypes["Vehicle"]>;
	}
}
```