### PR TITLE
fix variables in nested objects

### DIFF
--- a/src/TreeToTS/functions/inspectVariables.ts
+++ b/src/TreeToTS/functions/inspectVariables.ts
@@ -3,7 +3,7 @@ import { StringFunction } from './models';
 export const inspectVariablesFunction: StringFunction = {
   ts: `
 const inspectVariables = (query: string) => {
-  const regex = /\\\$\\b\\w*__ZEUS_VAR__\\[?[^!^\\]^\\s^,^\\)]*[!]?[\\]]?[!]?/g;
+  const regex = /\\\$\\b\\w*__ZEUS_VAR__\\[?[^!^\\]^\\s^,^\\)^\\}]*[!]?[\\]]?[!]?/g;
   let result;
   const AllVariables: string[] = [];
   while ((result = regex.exec(query))) {
@@ -19,7 +19,7 @@ const inspectVariables = (query: string) => {
   AllVariables.forEach((variable) => {
     while (filteredQuery.includes(variable)) {
       filteredQuery = filteredQuery.replace(variable, variable.split('__ZEUS_VAR__')[0]);
-    }  
+    }
   });
   return \`(\${AllVariables.map((a) => a.split('__ZEUS_VAR__'))
     .map(([variableName, variableType]) => \`\${variableName}:\${variableType}\`)
@@ -28,7 +28,7 @@ const inspectVariables = (query: string) => {
 `,
   js: `
 const inspectVariables = (query) => {
-  const regex = /\\\$\\b\\w*__ZEUS_VAR__\\[?[^!^\\]^\\s^,^\\)]*[!]?[\\]]?[!]?/g;
+  const regex = /\\\$\\b\\w*__ZEUS_VAR__\\[?[^!^\\]^\\s^,^\\)^\\}]*[!]?[\\]]?[!]?/g;
   let result;
   const AllVariables = [];
   while ((result = regex.exec(query))) {


### PR DESCRIPTION
Fixes problems with variables inside nested objects, graphql-zeus kept `}` in variable name.

```ts
query({
	getSomething: [
		{ by: { $`id` } },
		{
			name: true,
		}
	],
})
```

Generated GraphQL query with sytnax error `$id}`

```graphql
# formatted
query ($id: UUID) {
    getSomething(by: { id: $id} }) {
                            # ^  error down here
        name
    }
}
```