### PR TITLE
fix: allow optional arrays of non-nullable members

### DIFF
--- a/src/TreeToTS/functions/TypesPropsResolver.ts
+++ b/src/TreeToTS/functions/TypesPropsResolver.ts
@@ -32,13 +32,13 @@ export const TypesPropsResolver = ({
         const isRequired = resolvedValue.required ? '!' : '';
         let t = \`\${typeResolved}\`;
         if (isArray) {
-        if (isArrayRequired) {
-            t = \`\${t}!\`;
+          if (isRequired) {
+              t = \`\${t}!\`;
+          }
+          t = \`[\${t}]\`;
         }
-        t = \`[\${t}]\`;
-        }
-        if (isRequired) {
-        t = \`\${t}!\`;
+        f (isRequired || isArrayRequired) {
+              t = \`\${t}!\`;
         }
         return \`\\\$\${value.split(\`ZEUS_VAR$\`)[1]}__ZEUS_VAR__\${t}\`;
     }


### PR DESCRIPTION
Previously, Zeus would prevent using optional arrays as arguments. Using one resulted in this error:

`message: "Variable "$status" of type "[OrderStatus]!" used in position expecting type "[OrderStatus!]"."`

This pull request correctly constructs the arguments, allowing those queries to begin working.