### PR TITLE
Update Thunder example to return json.data

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ createCards();
 //         "name": "Raphaelle",
 //         "skills": [
 //             "RAIN",
-//             "THUNDER",
+//             "
+",
 //         ]
 //     },
 //     "cardById": {
@@ -233,7 +234,7 @@ const createCards = async () => {
       });
     }
     const json = await response.json();
-    return json;
+    return json.data;
   });
   const listCardsAndDraw = await thunder.query({
     cardById: [


### PR DESCRIPTION
Tried copying the example in the readme and it appears that if you want the result of thunder and chain to match you need to return json.data. So just a suggested update to the readme 