### PR TITLE
Add explicit types to top level exports (closes #178)

### DIFF
--- a/src/__tests__/TreeToTS/Selectors.spec.ts
+++ b/src/__tests__/TreeToTS/Selectors.spec.ts
@@ -12,7 +12,7 @@ describe('Thunder tests', () => {
   it('TypeScript: Selectors', () => {
     const tree = Parser.parseAddExtensions(schema);
     const typeScriptCode = TreeToTS.resolveTree(tree);
-    expect(typeScriptCode).toContain(`Selectors = {`);
+    expect(typeScriptCode).toContain(`Selectors: SelectorsRootType = {`);
     expect(typeScriptCode).toContain(`query: ZeusSelect<ValueTypes["Query"]>()`);
   });
   it('Javascript: Selectors', () => {


### PR DESCRIPTION
The typescript compiler was choking on compilation of zeus libs (#178) when used with large schemas due to AST complexity. Adding explicit typings to the generated module's exports fixes this. This reuses/refactors parameter type-string generation from existing methods to generate the types.

That being said, there is plenty of type-generalization that can be used to get rid of the existing duplicate code in the TreeToTS ops module.