### PR TITLE
Fixed Typescript output concatenation bug

### DIFF
--- a/src/TreeToTS/index.ts
+++ b/src/TreeToTS/index.ts
@@ -145,6 +145,6 @@ export class TreeToTS {
   }
   static resolveTree(tree: ParserTree, env: Environment = 'browser', host?: string) {
     const t = TreeToTS.resolveTreeSplit(tree, env, host);
-    return TreeToTS.resolveBasisHeader().concat(t.const).concat(t.index);
+    return TreeToTS.resolveBasisHeader().concat(t.const).concat('\n').concat(t.index);
   }
 }


### PR DESCRIPTION
Concatenation can cause syntax errors if the start of a type definition follows the end of an object literal without a line break