### PR TITLE
Replace: "export enum" -> "export const enum"

### DIFF
--- a/src/TreeToTS/templates/returnedTypes.ts
+++ b/src/TreeToTS/templates/returnedTypes.ts
@@ -60,7 +60,7 @@ const resolveEnum = (i: ParserField): string => {
   if (!i.args) {
     throw new Error('Empty enum error');
   }
-  return `${plusDescription(i.description)}export enum ${i.name} {\n${i.args
+  return `${plusDescription(i.description)}export const enum ${i.name} {\n${i.args
     .map((f) => `\t${f.name} = "${f.name}"`)
     .join(',\n')}\n}`;
 };


### PR DESCRIPTION
Use `export const enum` instead of `export enum` so that we can directly write ts enum in code.

```typescript
export enum EnumA = {
  a = 'a',
  b = 'b'
}

const obj = {
  columns: ['a' as EnumA.b] // not strict, enum won't be compiled into runtime, so it can only be used as type
  // columns: [EnumA.b] -> write this way  also works, it can be successfully compiled by tsc, but there will have a runtime error cause EnumA will be `undefined` in runtime.
} // ==> obj: {columns: ['a']} ; it was wrong here

// ----

export const enum EnumA = {
  a = 'a',
  b = 'b'
}

const obj = {
  columns: [EnumA.b] // strict
} // ==> obj: {columns: ['b']}; correct here
```