### PR TITLE
Adding a way to use directives on the Selectors

### DIFF
--- a/doc/src/markdown/plugins/apollo.md
+++ b/doc/src/markdown/plugins/apollo.md
@@ -33,6 +33,25 @@ const Main = () => {
 };
 ```
 
+### Apollo Client @client directive
+
+
+```tsx
+import { useTypedQuery } from './zeus/apollo';
+
+const Main = () => {
+  const { data } = useTypedQuery({
+    // Get autocomplete here:
+    drawCard: {
+      isCardSelected: '@client'
+    },
+  });
+  // this data comes from the local-only fields
+  // https://www.apollographql.com/docs/react/local-state/managing-state-with-field-policies/
+  return <div>{data.drawCard.isCardSelected}</div>;
+};
+```
+
 ### Inferring the response type for Apollo Client
 
 If you would like to infer the response type of your query for Apollo Client you can use the Zeus `Selector` function and `InputType` utility from the Zeus generated library

--- a/src/TreeToTS/functions/resolveKV.ts
+++ b/src/TreeToTS/functions/resolveKV.ts
@@ -2,7 +2,11 @@ import { StringFunction } from './models';
 
 export const resolveKVFunction: StringFunction = {
   ts: `
-const resolveKV = (k: string, v: boolean | string | { [x: string]: boolean | string }) =>
-  typeof v === 'boolean' ? k : typeof v === 'object' ? \`\${k}{\${objectToTree(v)}}\` : \`\${k}\${v}\`;
+const resolveKV = (k: string, v: boolean | string | { [x: string]: boolean | string }) => {
+  if (typeof v === "boolean") return k;
+  if (typeof v === "object") return \`\${k}{\${objectToTree(v)}}\`;
+  if (typeof v === "string") return \`\${k} \${v}\`;
+  return \`\${k}\${v}\`;
+};
 `,
 };

--- a/src/TreeToTS/functions/traverseToSeekArrays.ts
+++ b/src/TreeToTS/functions/traverseToSeekArrays.ts
@@ -11,6 +11,9 @@ const traverseToSeekArrays = (parent: string[], a?: any): string => {
   if (Array.isArray(a)) {
     return isArrayFunction([...parent], a);
   } else {
+    if (typeof a === "string" && a.startsWith("@")) {
+      return a;
+    }
     if (typeof a === 'object') {
       Object.keys(a)
         .filter((k) => typeof a[k] !== 'undefined')


### PR DESCRIPTION
Now if we use a string as a value of the selector, it uses that string in front of the key, enabling the use of directives on the selectors

ex:
```typescript
const cardSelector = Selector('Card')({
  name: true,
  isSelected: "@client"
});
```

The useQuery hook still thinks the value is `never`, I'm working to fix that