### PR TITLE
feat: add full esm module support for node env

### DIFF
--- a/examples/typescript-node-big-schema/src/zeus/reactQuery.ts
+++ b/examples/typescript-node-big-schema/src/zeus/reactQuery.ts
@@ -6,7 +6,7 @@ import type { UseMutationOptions, UseQueryOptions } from 'react-query';
 
 
 export function useTypedMutation<O extends "mutation_root", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
-  mutationKey: string,
+  mutationKey: string | unknown[],
   mutation: TData | ValueTypes[O],
   options?: Omit<UseMutationOptions<TResult>, 'mutationKey' | 'mutationFn'>,
   zeusOptions?: OperationOptions,
@@ -16,7 +16,7 @@ export function useTypedMutation<O extends "mutation_root", TData extends ValueT
   return useMutation<TResult>(mutationKey, () => Chain(host, hostOptions)("mutation")(mutation, zeusOptions) as Promise<TResult>, options);
 }
 export function useTypedQuery<O extends "query_root", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
-  queryKey: string,
+  queryKey: string | unknown[],
   query: TData | ValueTypes[O],
   options?: Omit<UseQueryOptions<TResult>, 'queryKey' | 'queryFn'>,
   zeusOptions?: OperationOptions,

--- a/examples/typescript-node/src/zeus/apollo.ts
+++ b/examples/typescript-node/src/zeus/apollo.ts
@@ -1,23 +1,23 @@
 /* eslint-disable */
 
 import { Zeus, GraphQLTypes, InputType, ValueTypes } from './index';
-import { gql, useMutation, useSubscription, useQuery, useLazyQuery } from '@apollo/client';
-import type { MutationHookOptions, SubscriptionHookOptions, QueryHookOptions, LazyQueryHookOptions } from '@apollo/client';
+import { gql, useSubscription, useMutation, useQuery, useLazyQuery } from '@apollo/client';
+import type { SubscriptionHookOptions, MutationHookOptions, QueryHookOptions, LazyQueryHookOptions } from '@apollo/client';
 
 
-export function useTypedMutation<Z extends ValueTypes[O], O extends "Mutation">(
-  mutation: Z | ValueTypes[O],
-  options?: MutationHookOptions<InputType<GraphQLTypes[O], Z>>,
-  operationName?: string,
-) {
-  return useMutation<InputType<GraphQLTypes[O], Z>>(gql(Zeus("mutation",mutation, operationName)), options);
-}
 export function useTypedSubscription<Z extends ValueTypes[O], O extends "Subscription">(
   subscription: Z | ValueTypes[O],
   options?: SubscriptionHookOptions<InputType<GraphQLTypes[O], Z>>,
   operationName?: string,
 ) {
   return useSubscription<InputType<GraphQLTypes[O], Z>>(gql(Zeus("subscription",subscription, operationName)), options);
+}
+export function useTypedMutation<Z extends ValueTypes[O], O extends "Mutation">(
+  mutation: Z | ValueTypes[O],
+  options?: MutationHookOptions<InputType<GraphQLTypes[O], Z>>,
+  operationName?: string,
+) {
+  return useMutation<InputType<GraphQLTypes[O], Z>>(gql(Zeus("mutation",mutation, operationName)), options);
 }
 export function useTypedQuery<Z extends ValueTypes[O], O extends "Query">(
   query: Z | ValueTypes[O],

--- a/examples/typescript-node/src/zeus/const.ts
+++ b/examples/typescript-node/src/zeus/const.ts
@@ -1,46 +1,7 @@
 /* eslint-disable */
 
 export const AllTypesProps: Record<string,any> = {
-	Card:{
-		attack:{
-			cardID:{
-				type:"String",
-				array:true,
-				arrayRequired:true,
-				required:true
-			}
-		}
-	},
-	SpecialSkills: "enum",
-	Mutation:{
-		addCard:{
-			card:{
-				type:"createCard",
-				array:false,
-				arrayRequired:false,
-				required:true
-			}
-		}
-	},
 	createCard:{
-		Defense:{
-			type:"Int",
-			array:false,
-			arrayRequired:false,
-			required:true
-		},
-		skills:{
-			type:"SpecialSkills",
-			array:true,
-			arrayRequired:false,
-			required:true
-		},
-		name:{
-			type:"String",
-			array:false,
-			arrayRequired:false,
-			required:true
-		},
 		description:{
 			type:"String",
 			array:false,
@@ -58,6 +19,44 @@ export const AllTypesProps: Record<string,any> = {
 			array:false,
 			arrayRequired:false,
 			required:true
+		},
+		Defense:{
+			type:"Int",
+			array:false,
+			arrayRequired:false,
+			required:true
+		},
+		skills:{
+			type:"SpecialSkills",
+			array:true,
+			arrayRequired:false,
+			required:true
+		},
+		name:{
+			type:"String",
+			array:false,
+			arrayRequired:false,
+			required:true
+		}
+	},
+	Card:{
+		attack:{
+			cardID:{
+				type:"String",
+				array:true,
+				arrayRequired:true,
+				required:true
+			}
+		}
+	},
+	Mutation:{
+		addCard:{
+			card:{
+				type:"createCard",
+				array:false,
+				arrayRequired:false,
+				required:true
+			}
 		}
 	},
 	Query:{
@@ -69,7 +68,8 @@ export const AllTypesProps: Record<string,any> = {
 				required:false
 			}
 		}
-	}
+	},
+	SpecialSkills: "enum"
 }
 
 export const ReturnTypes: Record<string,any> = {
@@ -90,18 +90,11 @@ export const ReturnTypes: Record<string,any> = {
 		key:"String",
 		region:"String"
 	},
-	SpecialCard:{
-		effect:"String",
-		name:"String"
-	},
-	Mutation:{
-		addCard:"Card"
-	},
 	Nameable:{
 		"...on Card": "Card",
 		"...on SpecialCard": "SpecialCard",
-		"...on CardStack": "CardStack",
 		"...on EffectCard": "EffectCard",
+		"...on CardStack": "CardStack",
 		name:"String"
 	},
 	ChangeCard:{
@@ -111,6 +104,21 @@ export const ReturnTypes: Record<string,any> = {
 	Subscription:{
 		deck:"Card"
 	},
+	SpecialCard:{
+		effect:"String",
+		name:"String"
+	},
+	EffectCard:{
+		effectSize:"Float",
+		name:"String"
+	},
+	CardStack:{
+		cards:"Card",
+		name:"String"
+	},
+	Mutation:{
+		addCard:"Card"
+	},
 	Query:{
 		cardById:"Card",
 		drawCard:"Card",
@@ -118,13 +126,5 @@ export const ReturnTypes: Record<string,any> = {
 		listCards:"Card",
 		myStacks:"CardStack",
 		nameables:"Nameable"
-	},
-	CardStack:{
-		cards:"Card",
-		name:"String"
-	},
-	EffectCard:{
-		effectSize:"Float",
-		name:"String"
 	}
 }

--- a/examples/typescript-node/src/zeus/index.ts
+++ b/examples/typescript-node/src/zeus/index.ts
@@ -1,11 +1,29 @@
 /* eslint-disable */
 
 import { AllTypesProps, ReturnTypes } from './const';
+import type fetch from 'node-fetch';
+import type WebSocket from 'ws';
+
 type ZEUS_INTERFACES = GraphQLTypes["Nameable"]
 type ZEUS_UNIONS = GraphQLTypes["ChangeCard"]
 
 export type ValueTypes = {
-    /** Card used in card game<br> */
+    /** create card inputs<br> */
+["createCard"]: {
+	/** Description of a card<br> */
+	description:string,
+	/** <div>How many children the greek god had</div> */
+	Children?:number | null,
+	/** The attack power<br> */
+	Attack:number,
+	/** The defense power<br> */
+	Defense:number,
+	/** input skills */
+	skills?:ValueTypes["SpecialSkills"][],
+	/** The name of a card<br> */
+	name:string
+};
+	/** Card used in card game<br> */
 ["Card"]: AliasType<{
 	/** The attack power<br> */
 	Attack?:boolean,
@@ -26,7 +44,6 @@ attack?: [{	/** Attacked card/card ids<br> */
 	skills?:boolean,
 		__typename?: boolean
 }>;
-	["SpecialSkills"]:SpecialSkills;
 	/** Aws S3 File */
 ["S3Object"]: AliasType<{
 	bucket?:boolean,
@@ -34,44 +51,40 @@ attack?: [{	/** Attacked card/card ids<br> */
 	region?:boolean,
 		__typename?: boolean
 }>;
-	["SpecialCard"]: AliasType<{
-	effect?:boolean,
-	name?:boolean,
-		__typename?: boolean
-}>;
-	["Mutation"]: AliasType<{
-addCard?: [{	card:ValueTypes["createCard"]},ValueTypes["Card"]],
-		__typename?: boolean
-}>;
 	["Nameable"]:AliasType<{
 		name?:boolean;
 		['...on Card']?: Omit<ValueTypes["Card"],keyof ValueTypes["Nameable"]>;
 		['...on SpecialCard']?: Omit<ValueTypes["SpecialCard"],keyof ValueTypes["Nameable"]>;
-		['...on CardStack']?: Omit<ValueTypes["CardStack"],keyof ValueTypes["Nameable"]>;
 		['...on EffectCard']?: Omit<ValueTypes["EffectCard"],keyof ValueTypes["Nameable"]>;
+		['...on CardStack']?: Omit<ValueTypes["CardStack"],keyof ValueTypes["Nameable"]>;
 		__typename?: boolean
 }>;
 	["ChangeCard"]: AliasType<{		["...on SpecialCard"] : ValueTypes["SpecialCard"],
 		["...on EffectCard"] : ValueTypes["EffectCard"]
 		__typename?: boolean
 }>;
-	/** create card inputs<br> */
-["createCard"]: {
-	/** The defense power<br> */
-	Defense:number,
-	/** input skills */
-	skills?:ValueTypes["SpecialSkills"][],
-	/** The name of a card<br> */
-	name:string,
-	/** Description of a card<br> */
-	description:string,
-	/** <div>How many children the greek god had</div> */
-	Children?:number | null,
-	/** The attack power<br> */
-	Attack:number
-};
 	["Subscription"]: AliasType<{
 	deck?:ValueTypes["Card"],
+		__typename?: boolean
+}>;
+	["SpecialCard"]: AliasType<{
+	effect?:boolean,
+	name?:boolean,
+		__typename?: boolean
+}>;
+	["EffectCard"]: AliasType<{
+	effectSize?:boolean,
+	name?:boolean,
+		__typename?: boolean
+}>;
+	/** Stack of cards */
+["CardStack"]: AliasType<{
+	cards?:ValueTypes["Card"],
+	name?:boolean,
+		__typename?: boolean
+}>;
+	["Mutation"]: AliasType<{
+addCard?: [{	card:ValueTypes["createCard"]},ValueTypes["Card"]],
 		__typename?: boolean
 }>;
 	["Query"]: AliasType<{
@@ -85,21 +98,13 @@ cardById?: [{	cardId?:string | null},ValueTypes["Card"]],
 	nameables?:ValueTypes["Nameable"],
 		__typename?: boolean
 }>;
-	/** Stack of cards */
-["CardStack"]: AliasType<{
-	cards?:ValueTypes["Card"],
-	name?:boolean,
-		__typename?: boolean
-}>;
-	["EffectCard"]: AliasType<{
-	effectSize?:boolean,
-	name?:boolean,
-		__typename?: boolean
-}>
+	["SpecialSkills"]:SpecialSkills
   }
 
 export type ModelTypes = {
-    /** Card used in card game<br> */
+    /** create card inputs<br> */
+["createCard"]: GraphQLTypes["createCard"];
+	/** Card used in card game<br> */
 ["Card"]: {
 		/** The attack power<br> */
 	Attack:number,
@@ -119,27 +124,33 @@ export type ModelTypes = {
 	name:string,
 	skills?:ModelTypes["SpecialSkills"][]
 };
-	["SpecialSkills"]: GraphQLTypes["SpecialSkills"];
 	/** Aws S3 File */
 ["S3Object"]: {
 		bucket:string,
 	key:string,
 	region:string
 };
+	["Nameable"]: ModelTypes["Card"] | ModelTypes["SpecialCard"] | ModelTypes["EffectCard"] | ModelTypes["CardStack"];
+	["ChangeCard"]:ModelTypes["SpecialCard"] | ModelTypes["EffectCard"];
+	["Subscription"]: {
+		deck?:ModelTypes["Card"][]
+};
 	["SpecialCard"]: {
 		effect:string,
+	name:string
+};
+	["EffectCard"]: {
+		effectSize:number,
+	name:string
+};
+	/** Stack of cards */
+["CardStack"]: {
+		cards?:ModelTypes["Card"][],
 	name:string
 };
 	["Mutation"]: {
 		/** add Card to Cards database<br> */
 	addCard:ModelTypes["Card"]
-};
-	["Nameable"]: ModelTypes["Card"] | ModelTypes["SpecialCard"] | ModelTypes["CardStack"] | ModelTypes["EffectCard"];
-	["ChangeCard"]:ModelTypes["SpecialCard"] | ModelTypes["EffectCard"];
-	/** create card inputs<br> */
-["createCard"]: GraphQLTypes["createCard"];
-	["Subscription"]: {
-		deck?:ModelTypes["Card"][]
 };
 	["Query"]: {
 		cardById?:ModelTypes["Card"],
@@ -151,19 +162,26 @@ export type ModelTypes = {
 	myStacks?:ModelTypes["CardStack"][],
 	nameables:ModelTypes["Nameable"][]
 };
-	/** Stack of cards */
-["CardStack"]: {
-		cards?:ModelTypes["Card"][],
-	name:string
-};
-	["EffectCard"]: {
-		effectSize:number,
-	name:string
-}
+	["SpecialSkills"]: GraphQLTypes["SpecialSkills"]
     }
 
 export type GraphQLTypes = {
-    /** Card used in card game<br> */
+    /** create card inputs<br> */
+["createCard"]: {
+		/** Description of a card<br> */
+	description: string,
+	/** <div>How many children the greek god had</div> */
+	Children?: number,
+	/** The attack power<br> */
+	Attack: number,
+	/** The defense power<br> */
+	Defense: number,
+	/** input skills */
+	skills?: Array<GraphQLTypes["SpecialSkills"]>,
+	/** The name of a card<br> */
+	name: string
+};
+	/** Card used in card game<br> */
 ["Card"]: {
 	__typename: "Card",
 	/** The attack power<br> */
@@ -184,7 +202,6 @@ export type GraphQLTypes = {
 	name: string,
 	skills?: Array<GraphQLTypes["SpecialSkills"]>
 };
-	["SpecialSkills"]: SpecialSkills;
 	/** Aws S3 File */
 ["S3Object"]: {
 	__typename: "S3Object",
@@ -192,47 +209,43 @@ export type GraphQLTypes = {
 	key: string,
 	region: string
 };
-	["SpecialCard"]: {
-	__typename: "SpecialCard",
-	effect: string,
-	name: string
-};
-	["Mutation"]: {
-	__typename: "Mutation",
-	/** add Card to Cards database<br> */
-	addCard: GraphQLTypes["Card"]
-};
 	["Nameable"]: {
-	__typename:"Card" | "SpecialCard" | "CardStack" | "EffectCard",
+	__typename:"Card" | "SpecialCard" | "EffectCard" | "CardStack",
 	name: string
 	['...on Card']: '__union' & GraphQLTypes["Card"];
 	['...on SpecialCard']: '__union' & GraphQLTypes["SpecialCard"];
-	['...on CardStack']: '__union' & GraphQLTypes["CardStack"];
 	['...on EffectCard']: '__union' & GraphQLTypes["EffectCard"];
+	['...on CardStack']: '__union' & GraphQLTypes["CardStack"];
 };
 	["ChangeCard"]:{
 	__typename:"SpecialCard" | "EffectCard"
 	['...on SpecialCard']: '__union' & GraphQLTypes["SpecialCard"];
 	['...on EffectCard']: '__union' & GraphQLTypes["EffectCard"];
 };
-	/** create card inputs<br> */
-["createCard"]: {
-		/** The defense power<br> */
-	Defense: number,
-	/** input skills */
-	skills?: Array<GraphQLTypes["SpecialSkills"]>,
-	/** The name of a card<br> */
-	name: string,
-	/** Description of a card<br> */
-	description: string,
-	/** <div>How many children the greek god had</div> */
-	Children?: number,
-	/** The attack power<br> */
-	Attack: number
-};
 	["Subscription"]: {
 	__typename: "Subscription",
 	deck?: Array<GraphQLTypes["Card"]>
+};
+	["SpecialCard"]: {
+	__typename: "SpecialCard",
+	effect: string,
+	name: string
+};
+	["EffectCard"]: {
+	__typename: "EffectCard",
+	effectSize: number,
+	name: string
+};
+	/** Stack of cards */
+["CardStack"]: {
+	__typename: "CardStack",
+	cards?: Array<GraphQLTypes["Card"]>,
+	name: string
+};
+	["Mutation"]: {
+	__typename: "Mutation",
+	/** add Card to Cards database<br> */
+	addCard: GraphQLTypes["Card"]
 };
 	["Query"]: {
 	__typename: "Query",
@@ -245,17 +258,7 @@ export type GraphQLTypes = {
 	myStacks?: Array<GraphQLTypes["CardStack"]>,
 	nameables: Array<GraphQLTypes["Nameable"]>
 };
-	/** Stack of cards */
-["CardStack"]: {
-	__typename: "CardStack",
-	cards?: Array<GraphQLTypes["Card"]>,
-	name: string
-};
-	["EffectCard"]: {
-	__typename: "EffectCard",
-	effectSize: number,
-	name: string
-}
+	["SpecialSkills"]: SpecialSkills
     }
 export const enum SpecialSkills {
 	THUNDER = "THUNDER",
@@ -578,7 +581,7 @@ const inspectVariables = (query: string) => {
 
 export const queryConstruct = (t: 'query' | 'mutation' | 'subscription', tName: string, operationName?: string) => (o: Record<any, any>) =>
   `${t.toLowerCase()}${operationName ? ' ' + operationName : ''}${inspectVariables(buildQuery(tName, o))}`;
-  
+
 
 export const fullChainConstruct = (fn: FetchFunction) => (t: 'query' | 'mutation' | 'subscription', tName: string) => (
   o: Record<any, any>,
@@ -654,25 +657,28 @@ const handleFetchResponse = (
       }).catch(reject);
     });
   }
-  return response.json();
+  return response.json() as Promise<GraphQLResponse>;
 };
 
-export const apiFetch = (options: fetchOptions) => (query: string, variables: Record<string, any> = {}) => {
+
+
+
+export const apiFetch = (options: fetchOptions) => async (query: string, variables: Record<string, any> = {}) => {
     let fetchFunction;
     let queryString = query;
     let fetchOptions = options[1] || {};
     try {
-        fetchFunction = require('node-fetch');
+        fetchFunction = await import('node-fetch').then(module => module.default);
     } catch (error) {
         throw new Error("Please install 'node-fetch' to use zeus in nodejs environment");
     }
     if (fetchOptions.method && fetchOptions.method === 'GET') {
-      try {
-          queryString = require('querystring').stringify(query);
-      } catch (error) {
-          throw new Error("Something gone wrong 'querystring' is a part of nodejs environment");
-      }
-      return fetchFunction(`${options[0]}?query=${queryString}`, fetchOptions)
+      // try {
+      //     queryString = require('querystring').stringify(query);
+      // } catch (error) {
+      //     throw new Error("Something gone wrong 'querystring' is a part of nodejs environment");
+      // }
+      return fetchFunction(`${options[0]}?query=${encodeURIComponent(queryString)}`, fetchOptions)
         .then(handleFetchResponse)
         .then((response: GraphQLResponse) => {
           if (response.errors) {
@@ -699,11 +705,11 @@ export const apiFetch = (options: fetchOptions) => (query: string, variables: Re
   };
   
 
-export const apiSubscription = (options: chainOptions) => (
+export const apiSubscription = (options: chainOptions) => async (
     query: string,
   ) => {
     try {
-      const WebSocket =  require('ws');
+      const WebSocket = await import('ws').then(module => module.default);
       const queryString = options[0] + '?query=' + encodeURIComponent(query);
       const wsString = queryString.replace('http', 'ws');
       const host = (options.length > 1 && options[1]?.websocket?.[0]) || wsString;
@@ -760,8 +766,8 @@ export const Thunder = (fn: FetchFunction) => <
 ) => <Z extends ValueTypes[R]>(o: Z | ValueTypes[R], ops?: OperationOptions) =>
   fullChainConstruct(fn)(operation, allOperations[operation])(o as any, ops) as Promise<InputType<GraphQLTypes[R], Z>>;
 
-export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));  
-  
+export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));
+
 export const SubscriptionThunder = (fn: SubscriptionFunction) => <
   O extends 'query' | 'mutation' | 'subscription',
   R extends keyof ValueTypes = GenericOperation<O>
@@ -774,7 +780,7 @@ export const SubscriptionThunder = (fn: SubscriptionFunction) => <
   fullSubscriptionConstruct(fn)(operation, allOperations[operation])(
     o as any,
     ops,
-  ) as SubscriptionToGraphQL<Z, GraphQLTypes[R]>;
+  ) as Promise<SubscriptionToGraphQL<Z, GraphQLTypes[R]>>;
 
 export const Subscription = (...options: chainOptions) => SubscriptionThunder(apiSubscription(options));
 export const Zeus = <

--- a/examples/typescript-node/src/zeus/reactQuery.ts
+++ b/examples/typescript-node/src/zeus/reactQuery.ts
@@ -6,7 +6,7 @@ import type { UseMutationOptions, UseQueryOptions } from 'react-query';
 
 
 export function useTypedMutation<O extends "Mutation", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
-  mutationKey: string,
+  mutationKey: string | unknown[],
   mutation: TData | ValueTypes[O],
   options?: Omit<UseMutationOptions<TResult>, 'mutationKey' | 'mutationFn'>,
   zeusOptions?: OperationOptions,
@@ -16,7 +16,7 @@ export function useTypedMutation<O extends "Mutation", TData extends ValueTypes[
   return useMutation<TResult>(mutationKey, () => Chain(host, hostOptions)("mutation")(mutation, zeusOptions) as Promise<TResult>, options);
 }
 export function useTypedQuery<O extends "Query", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
-  queryKey: string,
+  queryKey: string | unknown[],
   query: TData | ValueTypes[O],
   options?: Omit<UseQueryOptions<TResult>, 'queryKey' | 'queryFn'>,
   zeusOptions?: OperationOptions,

--- a/examples/typescript-node/zeus.graphql
+++ b/examples/typescript-node/zeus.graphql
@@ -1,3 +1,24 @@
+"""create card inputs<br>"""
+input createCard {
+  """Description of a card<br>"""
+  description: String!
+
+  """<div>How many children the greek god had</div>"""
+  Children: Int
+
+  """The attack power<br>"""
+  Attack: Int!
+
+  """The defense power<br>"""
+  Defense: Int!
+
+  """input skills"""
+  skills: [SpecialSkills!]
+
+  """The name of a card<br>"""
+  name: String!
+}
+
 """Card used in card game<br>"""
 type Card implements Nameable {
   """The attack power<br>"""
@@ -34,18 +55,6 @@ type Card implements Nameable {
   skills: [SpecialSkills!]
 }
 
-""""""
-enum SpecialSkills {
-  """Lower enemy defense -5<br>"""
-  THUNDER
-
-  """Attack multiple Cards at once<br>"""
-  RAIN
-
-  """50% chance to avoid any attack<br>"""
-  FIRE
-}
-
 """Aws S3 File"""
 type S3Object {
   """"""
@@ -59,6 +68,21 @@ type S3Object {
 }
 
 """"""
+interface Nameable {
+  """"""
+  name: String!
+}
+
+""""""
+union ChangeCard = SpecialCard | EffectCard
+
+""""""
+type Subscription {
+  """"""
+  deck: [Card!]
+}
+
+""""""
 type SpecialCard implements Nameable {
   """"""
   effect: String!
@@ -68,45 +92,27 @@ type SpecialCard implements Nameable {
 }
 
 """"""
+type EffectCard implements Nameable {
+  """"""
+  effectSize: Float!
+
+  """"""
+  name: String!
+}
+
+"""Stack of cards"""
+type CardStack implements Nameable {
+  """"""
+  cards: [Card!]
+
+  """"""
+  name: String!
+}
+
+""""""
 type Mutation {
   """add Card to Cards database<br>"""
   addCard(card: createCard!): Card!
-}
-
-""""""
-interface Nameable {
-  """"""
-  name: String!
-}
-
-""""""
-union ChangeCard = SpecialCard | EffectCard
-
-"""create card inputs<br>"""
-input createCard {
-  """The defense power<br>"""
-  Defense: Int!
-
-  """input skills"""
-  skills: [SpecialSkills!]
-
-  """The name of a card<br>"""
-  name: String!
-
-  """Description of a card<br>"""
-  description: String!
-
-  """<div>How many children the greek god had</div>"""
-  Children: Int
-
-  """The attack power<br>"""
-  Attack: Int!
-}
-
-""""""
-type Subscription {
-  """"""
-  deck: [Card!]
 }
 
 """"""
@@ -130,22 +136,16 @@ type Query {
   nameables: [Nameable!]!
 }
 
-"""Stack of cards"""
-type CardStack implements Nameable {
-  """"""
-  cards: [Card!]
-
-  """"""
-  name: String!
-}
-
 """"""
-type EffectCard implements Nameable {
-  """"""
-  effectSize: Float!
+enum SpecialSkills {
+  """Lower enemy defense -5<br>"""
+  THUNDER
 
-  """"""
-  name: String!
+  """Attack multiple Cards at once<br>"""
+  RAIN
+
+  """50% chance to avoid any attack<br>"""
+  FIRE
 }
 
 schema{

--- a/src/TreeToTS/index.ts
+++ b/src/TreeToTS/index.ts
@@ -129,7 +129,7 @@ export class TreeToTS {
       const: TreeToTS.resolveBasisCode(tree),
       index: TreeToTS.resolveBasisTypes(tree)
         .concat(graphqlErrorTypeScript.concat('\n').concat(constantTypesTypescript).concat('\n\n'))
-        .concat(typescriptFunctions(env))
+        .concat(typescriptFunctions(env, esModule))
         .concat(operations)
         .concat(host ? '\n\n' : '')
         .concat(host ? `export const Gql = Chain('${host}')` : ''),

--- a/src/TreeToTS/templates/typescript/browser/apiSubscription.ts
+++ b/src/TreeToTS/templates/typescript/browser/apiSubscription.ts
@@ -1,4 +1,4 @@
-export default `
+export default () => `
 export const apiSubscription = (options: chainOptions) => (
     query: string,
   ) => {

--- a/src/TreeToTS/templates/typescript/browser/fetchFunction.ts
+++ b/src/TreeToTS/templates/typescript/browser/fetchFunction.ts
@@ -1,4 +1,4 @@
-export default `
+export default () => `
 const handleFetchResponse = (
   response: Parameters<Extract<Parameters<ReturnType<typeof fetch>['then']>[0], Function>>[0]
 ): Promise<GraphQLResponse> => {

--- a/src/TreeToTS/templates/typescript/functions.ts
+++ b/src/TreeToTS/templates/typescript/functions.ts
@@ -17,7 +17,7 @@ import {
   fullSubscriptionConstruct,
 } from '@/TreeToTS/functions';
 
-export const typescriptFunctions = (env: Environment): string => `
+export const typescriptFunctions = (env: Environment, esModule?: boolean): string => `
 ${ZeusSelectFunction.ts}
 ${ScalarResolverFunction.ts}
 ${TypePropsResolverFunction.ts}
@@ -27,12 +27,12 @@ ${objectToTreeFunction.ts}
 ${traverseToSeekArraysFunction.ts}
 ${buildQueryFunction.ts}
 ${inspectVariablesFunction.ts}
-${queryConstructFunction.ts}  
+${queryConstructFunction.ts}
 ${fullChainConstructFunction.ts}
 ${fullSubscriptionConstruct.ts}
 ${seekForAliasesFunction.ts}
 ${VariableFunction.ts}
 ${resolverForFunction.ts}
-${require(`./${env}/fetchFunction`).default}
-${require(`./${env}/apiSubscription`).default}
+${require(`./${env}/fetchFunction`).default(esModule)}
+${require(`./${env}/apiSubscription`).default(esModule)}
 `;

--- a/src/TreeToTS/templates/typescript/node/apiSubscription.ts
+++ b/src/TreeToTS/templates/typescript/node/apiSubscription.ts
@@ -1,9 +1,9 @@
-export default `
-export const apiSubscription = (options: chainOptions) => (
+export default (esModule?: boolean) => `
+export const apiSubscription = (options: chainOptions) => async (
     query: string,
   ) => {
     try {
-      const WebSocket =  require('ws');
+      const WebSocket = ${require('./websocketsImport')[esModule ? 'cjsImport' : 'esmImport']}
       const queryString = options[0] + '?query=' + encodeURIComponent(query);
       const wsString = queryString.replace('http', 'ws');
       const host = (options.length > 1 && options[1]?.websocket?.[0]) || wsString;

--- a/src/TreeToTS/templates/typescript/node/fetchFunction.ts
+++ b/src/TreeToTS/templates/typescript/node/fetchFunction.ts
@@ -1,4 +1,4 @@
-export default `
+export default (esModule?: boolean) => `
 const handleFetchResponse = (
   response: Parameters<Extract<Parameters<ReturnType<typeof fetch>['then']>[0], Function>>[0]
 ): Promise<GraphQLResponse> => {
@@ -10,25 +10,28 @@ const handleFetchResponse = (
       }).catch(reject);
     });
   }
-  return response.json();
+  return response.json() as Promise<GraphQLResponse>;
 };
 
-export const apiFetch = (options: fetchOptions) => (query: string, variables: Record<string, any> = {}) => {
+
+
+
+export const apiFetch = (options: fetchOptions) => async (query: string, variables: Record<string, any> = {}) => {
     let fetchFunction;
     let queryString = query;
     let fetchOptions = options[1] || {};
     try {
-        fetchFunction = require('node-fetch');
+        fetchFunction = ${require('./fetchImport')[esModule ? 'cjsImport' : 'esmImport']}
     } catch (error) {
         throw new Error("Please install 'node-fetch' to use zeus in nodejs environment");
     }
     if (fetchOptions.method && fetchOptions.method === 'GET') {
-      try {
-          queryString = require('querystring').stringify(query);
-      } catch (error) {
-          throw new Error("Something gone wrong 'querystring' is a part of nodejs environment");
-      }
-      return fetchFunction(\`\${options[0]}?query=\${queryString}\`, fetchOptions)
+      // try {
+      //     queryString = require('querystring').stringify(query);
+      // } catch (error) {
+      //     throw new Error("Something gone wrong 'querystring' is a part of nodejs environment");
+      // }
+      return fetchFunction(\`\${options[0]}?query=\${encodeURIComponent(queryString)}\`, fetchOptions)
         .then(handleFetchResponse)
         .then((response: GraphQLResponse) => {
           if (response.errors) {

--- a/src/TreeToTS/templates/typescript/node/fetchImport.ts
+++ b/src/TreeToTS/templates/typescript/node/fetchImport.ts
@@ -1,1 +1,4 @@
-export default `import fetch from 'node-fetch';`;
+export default `import type fetch from 'node-fetch';`;
+
+export const esmImport = `await import('node-fetch').then(module => module.default);`;
+export const cjsImport = `require('node-fetch');`;

--- a/src/TreeToTS/templates/typescript/node/websocketsImport.ts
+++ b/src/TreeToTS/templates/typescript/node/websocketsImport.ts
@@ -1,1 +1,4 @@
-export default `import WebSocket from 'ws';`;
+export default `import type WebSocket from 'ws';`;
+
+export const esmImport = `await import('ws').then(module => module.default);`;
+export const cjsImport = `require('ws');`;

--- a/src/TreeToTS/templates/typescript/operations.ts
+++ b/src/TreeToTS/templates/typescript/operations.ts
@@ -34,8 +34,8 @@ export const Thunder = (fn: FetchFunction) => <
 ) => <Z extends ${VALUETYPES}[R]>(o: Z | ${VALUETYPES}[R], ops?: OperationOptions) =>
   fullChainConstruct(fn)(operation, allOperations[operation])(o as any, ops) as Promise<InputType<${TYPES}[R], Z>>;
 
-export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));  
-  
+export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));
+
 export const SubscriptionThunder = (fn: SubscriptionFunction) => <
   O extends ${orOpsType},
   R extends keyof ValueTypes = GenericOperation<O>
@@ -48,7 +48,7 @@ export const SubscriptionThunder = (fn: SubscriptionFunction) => <
   fullSubscriptionConstruct(fn)(operation, allOperations[operation])(
     o as any,
     ops,
-  ) as SubscriptionToGraphQL<Z, ${TYPES}[R]>;
+  ) as Promise<SubscriptionToGraphQL<Z, ${TYPES}[R]>>;
 
 export const Subscription = (...options: chainOptions) => SubscriptionThunder(apiSubscription(options));`;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,24 +2,6 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.4.7":
-  version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.15.tgz#0aa05ff2bb54092919b501ef348ade6330911670"
-  integrity sha512-CnlT9i7TgHagkKQNvti81A9KcbIMqgpUPGJJL6bg5spTsB2R/5J6E7qiPcMvXuuXwR2xe4FmE4Ey4HizStb8Hg==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@wry/context" "^0.6.0"
-    "@wry/equality" "^0.5.0"
-    "@wry/trie" "^0.3.0"
-    graphql-tag "^2.12.3"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.16.1"
-    prop-types "^15.7.2"
-    symbol-observable "^4.0.0"
-    ts-invariant "^0.9.0"
-    tslib "^2.3.0"
-    zen-observable-ts "~1.1.0"
-
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -1134,11 +1116,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@graphql-typed-document-node/core@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1527,11 +1504,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/zen-observable@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
-
 "@typescript-eslint/eslint-plugin@^4.15.0":
   version "4.32.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.32.0.tgz#46d2370ae9311092f2a6f7246d28357daf2d4e89"
@@ -1601,27 +1573,6 @@
   dependencies:
     "@typescript-eslint/types" "4.32.0"
     eslint-visitor-keys "^2.0.0"
-
-"@wry/context@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
-  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/equality@^0.5.0":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
-  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/trie@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
-  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
-  dependencies:
-    tslib "^2.3.0"
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -3491,19 +3442,12 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-graphql-js-tree@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/graphql-js-tree/-/graphql-js-tree-0.0.1.tgz#b3744b5a0680ade02d928deb4e81d0c627dd21f2"
-  integrity sha512-QbUkZBXAGMwWit0FyH+R7LNpj7+RGac4KaaEqI7o451wqrTzh1MC96+xZyCHuCbCzcLQZaLBh7r7MhwuIz3M7w==
+graphql-js-tree@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/graphql-js-tree/-/graphql-js-tree-0.0.3.tgz#280a9e7a6acc951567470daafc904624cfa21d62"
+  integrity sha512-X/AhG+XRmRHCYQRLEbQxdODF16kE9w0b5lDMLJVSpcQlEum/+QeWuHky9hRGXw1apkREQdEtbZ5QXbr2t8v8/A==
   dependencies:
     graphql "^15.4.0"
-
-graphql-tag@^2.12.3:
-  version "2.12.5"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
-  integrity sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==
-  dependencies:
-    tslib "^2.1.0"
 
 graphql@*, graphql@^15.4.0:
   version "15.6.0"
@@ -3607,13 +3551,6 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hoist-non-react-statics@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -4487,7 +4424,7 @@ jest@^25.2.4:
     import-local "^3.0.2"
     jest-cli "^25.5.4"
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -4782,13 +4719,6 @@ longest@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-2.0.1.tgz#781e183296aa94f6d4d916dc335d0d17aefa23f8"
   integrity sha1-eB4YMpaqlPbU2RbcM10NF676I/g=
-
-loose-envify@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -5191,11 +5121,6 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -5283,14 +5208,6 @@ opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
-
-optimism@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
-  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
-  dependencies:
-    "@wry/context" "^0.6.0"
-    "@wry/trie" "^0.3.0"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -5587,15 +5504,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -5639,7 +5547,7 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6434,11 +6342,6 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-symbol-observable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
-  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
-
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -6583,13 +6486,6 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-invariant@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
-  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
-  dependencies:
-    tslib "^2.1.0"
-
 ts-jest@^26.5.1:
   version "26.5.6"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
@@ -6628,7 +6524,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.1.0, tslib@^2.3.0:
+tslib@^2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -6722,10 +6618,10 @@ typescript-transform-paths@^2.0.0:
   dependencies:
     minimatch "^3.0.4"
 
-typescript@^4.1.2:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@^4.5.2:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -7113,16 +7009,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zen-observable-ts@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
-  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
-  dependencies:
-    "@types/zen-observable" "0.8.3"
-    zen-observable "0.8.15"
-
-zen-observable@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
-  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Added full support for esm modules in node env: When the `--es` flag ist specified then dynamic imports (`await import`) are used instead of `require()`. With this
- the package `node-fetch` in version v3 or greater can be used, which is an esm only module. 
- zeus can be used in esm node projects.

Considerations for future improvements: At the moment for the node env, it is always importing types for the `ws` and `node-fetch` package. By separating the type utility functions - which derive the GraphQL return types - from the fetch and subscription functions in their own files, these can be optionally generated and do not require a dependency on `ws` or `node-fetch` package by default.