### PR TITLE
fix: add return type for node-fetch response

### DIFF
--- a/src/TreeToTS/functions/new/apiFetch.ts
+++ b/src/TreeToTS/functions/new/apiFetch.ts
@@ -15,7 +15,7 @@ const handleFetchResponse = (response: Response): Promise<GraphQLResponse> => {
         .catch(reject);
     });
   }
-  return response.json();
+  return response.json() as Promise<GraphQLResponse>;
 };
 
 export const apiFetch = (options: fetchOptions) => (query: string, variables: Record<string, unknown> = {}) => {


### PR DESCRIPTION
Added type cast of node-fetch response: The response of node fetch v3 is `Promise<unknown>` instead of `Promise<any>` , so an explicit type cast to `Promise<GraphQLResponse>` is required.