### PR TITLE
✨ Expose better errors

### DIFF
--- a/examples/typescript-node/src/zeus/apollo.ts
+++ b/examples/typescript-node/src/zeus/apollo.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 
 import { Zeus, GraphQLTypes, InputType, ValueTypes, OperationOptions, ScalarDefinition } from './index';
-import { gql, useSubscription, useMutation, useQuery, useLazyQuery } from '@apollo/client';
-import type { SubscriptionHookOptions, MutationHookOptions, QueryHookOptions, LazyQueryHookOptions } from '@apollo/client';
+import { gql, useSubscription, useQuery, useLazyQuery, useMutation } from '@apollo/client';
+import type { SubscriptionHookOptions, QueryHookOptions, LazyQueryHookOptions, MutationHookOptions } from '@apollo/client';
 
 
 export function useTypedSubscription<Z extends ValueTypes[O], O extends "Subscription", SCLR extends ScalarDefinition>(
@@ -14,19 +14,6 @@ export function useTypedSubscription<Z extends ValueTypes[O], O extends "Subscri
   }
 ) {
   return useSubscription<InputType<GraphQLTypes[O], Z, SCLR>>(gql(Zeus("subscription",subscription, {
-    operationOptions: options?.operationOptions,
-    scalars: options?.scalars
-  })), options?.apolloOptions);
-}
-export function useTypedMutation<Z extends ValueTypes[O], O extends "Mutation", SCLR extends ScalarDefinition>(
-  mutation: Z | ValueTypes[O],
-  options?:{
-    apolloOptions?: MutationHookOptions<InputType<GraphQLTypes[O], Z, SCLR>>,
-    operationOptions?: OperationOptions,
-    scalars?: SCLR
-  }
-) {
-  return useMutation<InputType<GraphQLTypes[O], Z, SCLR>>(gql(Zeus("mutation",mutation, {
     operationOptions: options?.operationOptions,
     scalars: options?.scalars
   })), options?.apolloOptions);
@@ -53,6 +40,19 @@ export function useTypedLazyQuery<Z extends ValueTypes[O], O extends "Query", SC
   }
 ) {
   return useLazyQuery<InputType<GraphQLTypes[O], Z, SCLR>>(gql(Zeus("query",LazyQuery, {
+    operationOptions: options?.operationOptions,
+    scalars: options?.scalars
+  })), options?.apolloOptions);
+}
+export function useTypedMutation<Z extends ValueTypes[O], O extends "Mutation", SCLR extends ScalarDefinition>(
+  mutation: Z | ValueTypes[O],
+  options?:{
+    apolloOptions?: MutationHookOptions<InputType<GraphQLTypes[O], Z, SCLR>>,
+    operationOptions?: OperationOptions,
+    scalars?: SCLR
+  }
+) {
+  return useMutation<InputType<GraphQLTypes[O], Z, SCLR>>(gql(Zeus("mutation",mutation, {
     operationOptions: options?.operationOptions,
     scalars: options?.scalars
   })), options?.apolloOptions);

--- a/examples/typescript-node/src/zeus/const.ts
+++ b/examples/typescript-node/src/zeus/const.ts
@@ -2,65 +2,38 @@
 
 export const AllTypesProps: Record<string,any> = {
 	SpecialSkills: "enum" as const,
-	Mutation:{
-		addCard:{
-			card:"createCard"
-		}
-	},
 	createCard:{
 		skills:"SpecialSkills"
-	},
-	Query:{
-		cardById:{
-
-		}
 	},
 	Card:{
 		attack:{
 
 		}
 	},
-	JSON: `scalar.JSON` as const
+	JSON: `scalar.JSON` as const,
+	Query:{
+		cardById:{
+
+		}
+	},
+	Mutation:{
+		addCard:{
+			card:"createCard"
+		}
+	}
 }
 
 export const ReturnTypes: Record<string,any> = {
-	S3Object:{
-		bucket:"String",
-		key:"String",
-		region:"String"
-	},
-	Subscription:{
-		deck:"Card"
-	},
 	Nameable:{
+		"...on CardStack": "CardStack",
+		"...on Card": "Card",
 		"...on SpecialCard": "SpecialCard",
 		"...on EffectCard": "EffectCard",
-		"...on Card": "Card",
-		"...on CardStack": "CardStack",
 		name:"String"
 	},
-	Mutation:{
-		addCard:"Card"
-	},
-	ChangeCard:{
-		"...on SpecialCard":"SpecialCard",
-		"...on EffectCard":"EffectCard"
-	},
-	SpecialCard:{
-		effect:"String",
+	CardStack:{
+		cards:"Card",
 		name:"String"
-	},
-	EffectCard:{
-		effectSize:"Float",
-		name:"String"
-	},
-	Query:{
-		cardById:"Card",
-		drawCard:"Card",
-		drawChangeCard:"ChangeCard",
-		listCards:"Card",
-		myStacks:"CardStack",
-		nameables:"Nameable"
 	},
 	Card:{
 		Attack:"Int",
@@ -75,15 +48,42 @@ export const ReturnTypes: Record<string,any> = {
 		name:"String",
 		skills:"SpecialSkills"
 	},
-	JSON: `scalar.JSON` as const,
-	CardStack:{
-		cards:"Card",
+	SpecialCard:{
+		effect:"String",
 		name:"String"
+	},
+	JSON: `scalar.JSON` as const,
+	ChangeCard:{
+		"...on SpecialCard":"SpecialCard",
+		"...on EffectCard":"EffectCard"
+	},
+	EffectCard:{
+		effectSize:"Float",
+		name:"String"
+	},
+	Subscription:{
+		deck:"Card"
+	},
+	S3Object:{
+		bucket:"String",
+		key:"String",
+		region:"String"
+	},
+	Query:{
+		cardById:"Card",
+		drawCard:"Card",
+		drawChangeCard:"ChangeCard",
+		listCards:"Card",
+		myStacks:"CardStack",
+		nameables:"Nameable"
+	},
+	Mutation:{
+		addCard:"Card"
 	}
 }
 
 export const Ops = {
 subscription: "Subscription" as const,
-	mutation: "Mutation" as const,
-	query: "Query" as const
+	query: "Query" as const,
+	mutation: "Mutation" as const
 }

--- a/examples/typescript-node/src/zeus/reactQuery.ts
+++ b/examples/typescript-node/src/zeus/reactQuery.ts
@@ -1,20 +1,10 @@
 /* eslint-disable */
 
 import { ValueTypes, GraphQLTypes, InputType, Chain, OperationOptions, chainOptions } from './index';
-import { useMutation, useQuery } from 'react-query';
-import type { UseMutationOptions, UseQueryOptions } from 'react-query';
+import { useQuery, useMutation } from 'react-query';
+import type { UseQueryOptions, UseMutationOptions } from 'react-query';
 
 
-export function useTypedMutation<O extends "Mutation", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
-  mutationKey: string | unknown[],
-  mutation: TData | ValueTypes[O],
-  options?: Omit<UseMutationOptions<TResult, any, any>, 'mutationKey' | 'mutationFn'>,
-  zeusOptions?: OperationOptions,
-  host = "https://faker.graphqleditor.com/a-team/olympus/graphql",
-  hostOptions: chainOptions[1] = {},
-) {
-  return useMutation<TResult, any, any>(mutationKey, () => Chain(host, hostOptions)("mutation")(mutation, zeusOptions) as Promise<TResult>, options);
-}
 export function useTypedQuery<O extends "Query", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
   queryKey: string | unknown[],
   query: TData | ValueTypes[O],
@@ -24,4 +14,14 @@ export function useTypedQuery<O extends "Query", TData extends ValueTypes[O], TR
   hostOptions: chainOptions[1] = {},
 ) {
   return useQuery<TResult, any, any>(queryKey, () => Chain(host, hostOptions)("query")(query, zeusOptions) as Promise<TResult>, options);
+}
+export function useTypedMutation<O extends "Mutation", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
+  mutationKey: string | unknown[],
+  mutation: TData | ValueTypes[O],
+  options?: Omit<UseMutationOptions<TResult, any, any>, 'mutationKey' | 'mutationFn'>,
+  zeusOptions?: OperationOptions,
+  host = "https://faker.graphqleditor.com/a-team/olympus/graphql",
+  hostOptions: chainOptions[1] = {},
+) {
+  return useMutation<TResult, any, any>(mutationKey, () => Chain(host, hostOptions)("mutation")(mutation, zeusOptions) as Promise<TResult>, options);
 }

--- a/examples/typescript-node/zeus.graphql
+++ b/examples/typescript-node/zeus.graphql
@@ -1,27 +1,3 @@
-"""Aws S3 File"""
-type S3Object {
-  """"""
-  bucket: String!
-
-  """"""
-  key: String!
-
-  """"""
-  region: String!
-}
-
-""""""
-type Subscription {
-  """"""
-  deck: [Card!]
-}
-
-""""""
-interface Nameable {
-  """"""
-  name: String!
-}
-
 """"""
 enum SpecialSkills {
   """Lower enemy defense -5<br>"""
@@ -35,9 +11,18 @@ enum SpecialSkills {
 }
 
 """"""
-type Mutation {
-  """add Card to Cards database<br>"""
-  addCard(card: createCard!): Card!
+interface Nameable {
+  """"""
+  name: String!
+}
+
+"""Stack of cards"""
+type CardStack implements Nameable {
+  """"""
+  cards: [Card!]
+
+  """"""
+  name: String!
 }
 
 """create card inputs<br>"""
@@ -59,48 +44,6 @@ input createCard {
 
   """The defense power<br>"""
   Defense: Int!
-}
-
-""""""
-union ChangeCard = SpecialCard | EffectCard
-
-""""""
-type SpecialCard implements Nameable {
-  """"""
-  effect: String!
-
-  """"""
-  name: String!
-}
-
-""""""
-type EffectCard implements Nameable {
-  """"""
-  effectSize: Float!
-
-  """"""
-  name: String!
-}
-
-""""""
-type Query {
-  """"""
-  cardById(cardId: String): Card
-
-  """Draw a card<br>"""
-  drawCard: Card!
-
-  """"""
-  drawChangeCard: ChangeCard!
-
-  """list All Cards availble<br>"""
-  listCards: [Card!]!
-
-  """"""
-  myStacks: [CardStack!]
-
-  """"""
-  nameables: [Nameable!]!
 }
 
 """Card used in card game<br>"""
@@ -143,15 +86,72 @@ type Card implements Nameable {
 }
 
 """"""
-scalar JSON
-
-"""Stack of cards"""
-type CardStack implements Nameable {
+type SpecialCard implements Nameable {
   """"""
-  cards: [Card!]
+  effect: String!
 
   """"""
   name: String!
+}
+
+""""""
+scalar JSON
+
+""""""
+union ChangeCard = SpecialCard | EffectCard
+
+""""""
+type EffectCard implements Nameable {
+  """"""
+  effectSize: Float!
+
+  """"""
+  name: String!
+}
+
+""""""
+type Subscription {
+  """"""
+  deck: [Card!]
+}
+
+"""Aws S3 File"""
+type S3Object {
+  """"""
+  bucket: String!
+
+  """"""
+  key: String!
+
+  """"""
+  region: String!
+}
+
+""""""
+type Query {
+  """"""
+  cardById(cardId: String): Card
+
+  """Draw a card<br>"""
+  drawCard: Card!
+
+  """"""
+  drawChangeCard: ChangeCard!
+
+  """list All Cards availble<br>"""
+  listCards: [Card!]!
+
+  """"""
+  myStacks: [CardStack!]
+
+  """"""
+  nameables: [Nameable!]!
+}
+
+""""""
+type Mutation {
+  """add Card to Cards database<br>"""
+  addCard(card: createCard!): Card!
 }
 schema{
 	query: Query,

--- a/src/TreeToTS/functions/generated.ts
+++ b/src/TreeToTS/functions/generated.ts
@@ -25,7 +25,7 @@ export const apiFetch =
         .then(handleFetchResponse)
         .then((response: GraphQLResponse) => {
           if (response.errors) {
-            throw new GraphQLError(response);
+            throw new ZeusError(response);
           }
           return response.data;
         });
@@ -41,7 +41,7 @@ export const apiFetch =
       .then(handleFetchResponse)
       .then((response: GraphQLResponse) => {
         if (response.errors) {
-          throw new GraphQLError(response);
+          throw new ZeusError(response);
         }
         return response.data;
       });
@@ -340,21 +340,35 @@ export type OperationOptions = {
 
 export type ScalarCoder = Record<string, (s: unknown) => string>;
 
+import { GraphQLError, type GraphQLErrorOptions } from 'graphql'; // keep
+
 export interface GraphQLResponse {
   data?: Record<string, any>;
-  errors?: Array<{
-    message: string;
-  }>;
+  errors?: Array<{ message: string } & GraphQLErrorOptions>;
 }
-export class GraphQLError extends Error {
-  constructor(public response: GraphQLResponse) {
-    super('');
-    console.error(response);
+
+export class ZeusError extends Error implements GraphQLResponse {
+  name = 'ZeusError';
+  public readonly data: Record<string, any> | undefined;
+  public readonly errors: GraphQLError[] = [];
+  constructor(public readonly response: GraphQLResponse) {
+    super(
+      response.errors && response.errors.length > 0
+        ? \`\${response.errors.length} GraphQL error\${response.errors.length > 1 ? 's' : ''}\`
+        : 'the response does not contain any errors',
+    );
+    if (response.errors && response.errors.length > 0) {
+      this.errors = response.errors.map(({ message, ...options }) => new GraphQLError(message, options));
+    }
   }
-  toString() {
-    return 'GraphQL Response Error';
+  toJSON() {
+    return this.response;
   }
 }
+
+// TODO: remove in v6
+export { ZeusError as GraphQLError };
+
 export type GenericOperation<O> = O extends keyof typeof Ops ? typeof Ops[O] : never;
 export type ThunderGraphQLOptions<SCLR extends ScalarDefinition> = {
   scalars?: SCLR | ScalarCoders;

--- a/src/TreeToTS/functions/new/apiFetch.ts
+++ b/src/TreeToTS/functions/new/apiFetch.ts
@@ -1,4 +1,4 @@
-import { fetchOptions, GraphQLError, GraphQLResponse } from '@/TreeToTS/functions/new/models';
+import { fetchOptions, ZeusError, GraphQLResponse } from '@/TreeToTS/functions/new/models';
 
 const handleFetchResponse = (response: Response): Promise<GraphQLResponse> => {
   if (!response.ok) {
@@ -27,7 +27,7 @@ export const apiFetch =
         .then(handleFetchResponse)
         .then((response: GraphQLResponse) => {
           if (response.errors) {
-            throw new GraphQLError(response);
+            throw new ZeusError(response);
           }
           return response.data;
         });
@@ -43,7 +43,7 @@ export const apiFetch =
       .then(handleFetchResponse)
       .then((response: GraphQLResponse) => {
         if (response.errors) {
-          throw new GraphQLError(response);
+          throw new ZeusError(response);
         }
         return response.data;
       });

--- a/src/TreeToTS/functions/new/models.ts
+++ b/src/TreeToTS/functions/new/models.ts
@@ -65,21 +65,35 @@ export type OperationOptions = {
 
 export type ScalarCoder = Record<string, (s: unknown) => string>;
 
+import { GraphQLError, type GraphQLErrorOptions } from 'graphql'; // keep
+
 export interface GraphQLResponse {
   data?: Record<string, any>;
-  errors?: Array<{
-    message: string;
-  }>;
+  errors?: Array<{ message: string } & GraphQLErrorOptions>;
 }
-export class GraphQLError extends Error {
-  constructor(public response: GraphQLResponse) {
-    super('');
-    console.error(response);
+
+export class ZeusError extends Error implements GraphQLResponse {
+  name = 'ZeusError';
+  public readonly data: Record<string, any> | undefined;
+  public readonly errors: GraphQLError[] = [];
+  constructor(public readonly response: GraphQLResponse) {
+    super(
+      response.errors && response.errors.length > 0
+        ? `${response.errors.length} GraphQL error${response.errors.length > 1 ? 's' : ''}`
+        : 'the response does not contain any errors',
+    );
+    if (response.errors && response.errors.length > 0) {
+      this.errors = response.errors.map(({ message, ...options }) => new GraphQLError(message, options));
+    }
   }
-  toString() {
-    return 'GraphQL Response Error';
+  toJSON() {
+    return this.response;
   }
 }
+
+// TODO: remove in v6
+export { ZeusError as GraphQLError };
+
 export type GenericOperation<O> = O extends keyof typeof Ops ? typeof Ops[O] : never;
 export type ThunderGraphQLOptions<SCLR extends ScalarDefinition> = {
   scalars?: SCLR | ScalarCoders;

--- a/src/TreeToTS/index.ts
+++ b/src/TreeToTS/index.ts
@@ -114,9 +114,9 @@ import WebSocket from 'ws';`
       ),
       const: TreeToTS.resolveBasisCode(tree),
       index: ''
-        .concat(host ? `export const HOST = "${host}"` : '\n\nexport const HOST="Specify host"')
+        .concat(`export const HOST = ${JSON.stringify(host ?? 'Specify host')};`)
         .concat('\n')
-        .concat(headers ? `export const HEADERS = ${JSON.stringify(headers)}` : '\n\nexport const HEADERS = {}')
+        .concat(`export const HEADERS = ${JSON.stringify(headers ?? {})};`)
         .concat('\n')
         .concat(subscriptionFunctions[subscriptions])
         .concat('\n')


### PR DESCRIPTION
GraphQL v16.5.0 has introduced new types that we can leverage to expose better errors.

Features introduced by this PR:
- [x] Introduced a new class named `ZeusError`, replacing the confusing `GraphQLError`
- [x] Expose errors as an array of `GraphQLError`s
- [x] `ZeusError` is fully serializable and parse-able (`new ZeusError(JSON.parse(JSON.serialize(zeusError)))` works great if you don't care about stack-traces)

Breaking changes: *none*

I also refreshed the examples.