### PR TITLE
fix: variable generation with no enums

### DIFF
--- a/src/TreeToTS/templates/variableTypes/index.ts
+++ b/src/TreeToTS/templates/variableTypes/index.ts
@@ -12,5 +12,5 @@ export const resolveVariableTypes = (rootNodes: ParserField[]): string => {
     )
     .map((rn) => `\t["${rn.name}"]: ${VALUETYPES}["${rn.name}"];`)
     .join('\n');
-  return `type ${ZEUS_VARIABLES} = ${variableTypes ? `{\n${variableTypes}\n}` : 'never'}`;
+  return `type ${ZEUS_VARIABLES} = ${variableTypes ? `{\n${variableTypes}\n}` : '{}'}`;
 };


### PR DESCRIPTION
Changed empty ZEUS_VARIABLES to empty object instead of never.
fixes #327 