### PR TITLE
Don't decode null values

### DIFF
--- a/src/TreeToTS/functions/generated.ts
+++ b/src/TreeToTS/functions/generated.ts
@@ -260,6 +260,9 @@ export const traverseResponse = ({
     if (Array.isArray(o)) {
       return o.map((eachO) => ibb(k, eachO, p));
     }
+    if (o == null) {
+      return o;
+    }
     const scalarPathString = p.join(SEPARATOR);
     const currentScalarString = scalarPaths[scalarPathString];
     if (currentScalarString) {

--- a/src/TreeToTS/functions/new/decodeScalarsInResponse.ts
+++ b/src/TreeToTS/functions/new/decodeScalarsInResponse.ts
@@ -47,6 +47,9 @@ export const traverseResponse = ({
     if (Array.isArray(o)) {
       return o.map((eachO) => ibb(k, eachO, p));
     }
+    if (o == null) {
+      return o;
+    }
     const scalarPathString = p.join(SEPARATOR);
     const currentScalarString = scalarPaths[scalarPathString];
     if (currentScalarString) {


### PR DESCRIPTION
Early return for null values - avoids running them through a decoder if provided to ensure decoders receive only non-null fields.

Fixes #329 