### PR TITLE
Fix Scalar Path generation for queries with inline fragments

### DIFF
--- a/src/TreeToTS/functions/generated.ts
+++ b/src/TreeToTS/functions/generated.ts
@@ -422,9 +422,18 @@ export const PrepareScalarPaths = ({ ops, returns }: { returns: ReturnTypesType;
     const keyName = root ? ops[k] : k;
     return Object.entries(o)
       .filter(([k]) => k !== '__directives')
-      .map(([k, v]) =>
-        ibb(k, k, v, [...p, purifyGraphQLKey(keyName || k)], [...pOriginals, purifyGraphQLKey(originalKey)], false),
-      )
+      .map(([k, v]) => {
+        // Inline fragments shouldn't be added to the path as they aren't a field
+        const isInlineFragment = originalKey.match(/^...\\s*on/) != null;
+        return ibb(
+          k,
+          k,
+          v,
+          isInlineFragment ? p : [...p, purifyGraphQLKey(keyName || k)],
+          isInlineFragment ? pOriginals : [...pOriginals, purifyGraphQLKey(originalKey)],
+          false,
+        );
+      })
       .reduce((a, b) => ({
         ...a,
         ...b,

--- a/src/TreeToTS/functions/new/decodeScalarsInResponse.spec.ts
+++ b/src/TreeToTS/functions/new/decodeScalarsInResponse.spec.ts
@@ -34,4 +34,40 @@ describe('Scalars in response get decoded', () => {
     });
     expect(decodedResponse['drawCard']?.['info']).toEqual(cardInfo);
   });
+
+  test('Inline fragments get decoded correctly', () => {
+    const cardInfo = {
+      power: 9001,
+      speed: 100,
+    };
+    const response = {
+      drawCard: {
+        name: 'Adanos',
+        info: JSON.stringify(cardInfo),
+      },
+    };
+
+    const decodedResponse = decodeScalarsInResponse({
+      ops: Ops,
+      response,
+      returns: ReturnTypes,
+      initialOp: 'query',
+      initialZeusQuery: {
+        drawCard: {
+          '...on Card': {
+            name: true,
+            info: true,
+          },
+        },
+      },
+      scalars: {
+        JSON: {
+          decode: (e) => {
+            return JSON.parse(e as string) as typeof cardInfo;
+          },
+        },
+      },
+    });
+    expect(decodedResponse['drawCard']?.['info']).toEqual(cardInfo);
+  });
 });

--- a/src/TreeToTS/functions/new/prepareScalarPaths.spec.ts
+++ b/src/TreeToTS/functions/new/prepareScalarPaths.spec.ts
@@ -3,7 +3,7 @@ import { PrepareScalarPaths } from '@/TreeToTS/functions/new/prepareScalarPaths'
 
 const builder = PrepareScalarPaths({ returns: ReturnTypes, ops: Ops });
 
-describe('Test generated function buildQuery', () => {
+describe('Test PrepareScalarPaths function', () => {
   test('Simple query', () => {
     const matchExact = builder('query', 'Query', {
       cards: {
@@ -11,6 +11,19 @@ describe('Test generated function buildQuery', () => {
         age: true,
         info: true,
         bio: true,
+      },
+    });
+    const o = {
+      'Query|cards|info': 'scalar.JSON',
+    };
+    expect(o).toEqual(matchExact);
+  });
+  test('Discards inline fragment from path', () => {
+    const matchExact = builder('query', 'Query', {
+      cards: {
+        '... on Card': {
+          info: true,
+        },
       },
     });
     const o = {

--- a/src/TreeToTS/functions/new/prepareScalarPaths.ts
+++ b/src/TreeToTS/functions/new/prepareScalarPaths.ts
@@ -63,9 +63,18 @@ export const PrepareScalarPaths = ({ ops, returns }: { returns: ReturnTypesType;
     const keyName = root ? ops[k] : k;
     return Object.entries(o)
       .filter(([k]) => k !== '__directives')
-      .map(([k, v]) =>
-        ibb(k, k, v, [...p, purifyGraphQLKey(keyName || k)], [...pOriginals, purifyGraphQLKey(originalKey)], false),
-      )
+      .map(([k, v]) => {
+        // Inline fragments shouldn't be added to the path as they aren't a field
+        const isInlineFragment = originalKey.match(/^...\s*on/) != null;
+        return ibb(
+          k,
+          k,
+          v,
+          isInlineFragment ? p : [...p, purifyGraphQLKey(keyName || k)],
+          isInlineFragment ? pOriginals : [...pOriginals, purifyGraphQLKey(originalKey)],
+          false,
+        );
+      })
       .reduce((a, b) => ({
         ...a,
         ...b,


### PR DESCRIPTION
If a query contains an inline fragment to select a specific type from a union type, currently the `PrepareScalarPaths` function will add the inline fragment to the path list. However, when a response is being decoded, this inline fragment is not present on the generated path for a scalar, and so custom scalars can't find their correct decoder.

For e.g:

```gql
cards {
  ... on Card {
    info
  }
}
```

will result in the scalar path being generated as `['Query', 'cards', '... on Card', 'info']`, however the response scalar path is generated as `['Query', 'cards', 'info']`, as an inline fragment isn't a field