### PR TITLE
React Query v3 Support

### DIFF
--- a/packages/graphql-zeus/plugins/react-query/index.ts
+++ b/packages/graphql-zeus/plugins/react-query/index.ts
@@ -16,12 +16,12 @@ const pluginReactQueryOps = ({
     ts: `export function useTyped${capitalized}<O extends "${queryName}", TData extends ValueTypes[O], TResult = InputType<GraphQLTypes[O], TData>>(
   ${operation}Key: string | unknown[],
   ${operation}: TData | ValueTypes[O],
-  options?: Omit<Use${capitalized}Options<TResult, any, any>, '${operation}Key' | '${operation}Fn'>,
+  options?: Omit<Use${capitalized}Options<TResult>, '${operation}Key' | '${operation}Fn'>,
   zeusOptions?: OperationOptions,
   host = "${host || ''}",
   hostOptions: chainOptions[1] = {},
 ) {
-  return use${capitalized}<TResult, any, any>(${operation}Key, () => Chain(host, hostOptions)("${operation}")(${operation}, zeusOptions) as Promise<TResult>, options);
+  return use${capitalized}<TResult>(${operation}Key, () => Chain(host, hostOptions)("${operation}")(${operation}, zeusOptions) as Promise<TResult>, options);
 }`,
   };
 };


### PR DESCRIPTION
Currently the react-query implementation only works with react-query v2. In v3 the generic types passed to the hooks have changed.

They're optional so the two extra `any` types aren't needed, but they override the TResult that is used to describe the data.