### PR TITLE
Fix zeus generated file when using graphql-ws subscriptions and Node

### DIFF
--- a/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
@@ -1,3 +1,5 @@
+import type { Environment } from '@/Models';
+
 export default `const handleFetchResponse = (response: Response): Promise<GraphQLResponse> => {
   if (!response.ok) {
     return new Promise((_, reject) => {
@@ -799,14 +801,15 @@ export const $ = <Type extends GraphQLVariableType, Name extends string>(name: N
   return (START_VAR_NAME + name + GRAPHQL_TYPE_SEPARATOR + graphqlType) as unknown as Variable<Type, Name>;
 };`;
 
-export const subscriptionFunctions = {
+export const subscriptionFunctions = (env: Environment) => ({
   'graphql-ws': `import { createClient, type Sink } from 'graphql-ws'; // keep
 
 export const apiSubscription = (options: chainOptions) => {
   const client = createClient({
     url: String(options[0]),
-    connectionParams: Object.fromEntries(new Headers(options[1]?.headers).entries()),
-    webSocketImpl: WebSocket,
+    connectionParams: Object.fromEntries(new Headers(options[1]?.headers).entries()),${
+      env === 'node' ? '\n    webSocketImpl: WebSocket,' : ''
+    }
   });
 
   const ws = new Proxy(
@@ -890,4 +893,4 @@ export const apiSubscription = (options: chainOptions) => {
     throw new Error('No websockets implemented');
   }
 };`,
-};
+});

--- a/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
@@ -806,6 +806,7 @@ export const apiSubscription = (options: chainOptions) => {
   const client = createClient({
     url: String(options[0]),
     connectionParams: Object.fromEntries(new Headers(options[1]?.headers).entries()),
+    webSocketImpl: WebSocket,
   });
 
   const ws = new Proxy(

--- a/packages/graphql-zeus-core/TreeToTS/index.ts
+++ b/packages/graphql-zeus-core/TreeToTS/index.ts
@@ -120,7 +120,7 @@ import WebSocket from 'ws';`
         .concat('\n')
         .concat(headers ? `export const HEADERS = ${JSON.stringify(headers)}` : '\n\nexport const HEADERS = {}')
         .concat('\n')
-        .concat(subscriptionFunctions[subscriptions])
+        .concat(subscriptionFunctions(env)[subscriptions])
         .concat('\n')
         .concat(typescriptFunctions)
         .concat('\n')

--- a/packages/graphql-zeus-core/TreeToTS/index.ts
+++ b/packages/graphql-zeus-core/TreeToTS/index.ts
@@ -110,7 +110,7 @@ export class TreeToTS {
       }';`.concat(
         env === 'node'
           ? `
-import fetch, { Response } from 'node-fetch';
+import fetch, {${subscriptions === 'graphql-ws' ? ' Headers,' : ''} Response } from 'node-fetch';
 import WebSocket from 'ws';`
           : ``,
       ),


### PR DESCRIPTION
The file generated by Zeus is missing a few things when using both the `--n` (target Node) and `--subscriptions graphql-ws` (subscriptions with `graphql-ws` lib instead of the legacy websocket client):
1. We must import the `Headers` type from `@types/node-fetch` as the type definition is not compatible with the one from TS lib DOM (Headers in the browser).
2. for Node, according the graphql-ws recipes (https://the-guild.dev/graphql/ws/recipes), the `webSocketImpl` param must be passed to the `createClient` function, as Node doesn't have an out-of-the-box implementation of WebSocket as the browsers do

Point 1 creates a `tsc` compile time error.
Point 2 creates a runtime `graphql-ws` error.

Open question:
What to do with the `apiSubscription` function? I didn't know out to distinguish between the node or the browser for this function and how we could pass it a WebSocket implementation in the case of Node and graphql-ws.
