### PR TITLE
Strict input shape checking on Chain inputs

### DIFF
--- a/examples/typescript-node/src/zeus/index.ts
+++ b/examples/typescript-node/src/zeus/index.ts
@@ -167,9 +167,11 @@ export const Thunder =
     graphqlOptions?: ThunderGraphQLOptions<OVERRIDESCLR>,
   ) =>
   <Z extends ValueTypes[R]>(
-    o: Z & {
-      [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
-    },
+    o:
+      | (ValueTypes[R] & (typeof Ops)[O])
+      | {
+          [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
+        },
     ops?: OperationOptions & { variables?: Record<string, unknown> },
   ) => {
     const options = {
@@ -462,7 +464,7 @@ export class GraphQLError extends Error {
     return 'GraphQL Response Error';
   }
 }
-export type GenericOperation<O> = O extends keyof typeof Ops ? typeof Ops[O] : never;
+export type GenericOperation<O> = O extends keyof typeof Ops ? (typeof Ops)[O] : never;
 export type ThunderGraphQLOptions<SCLR extends ScalarDefinition> = {
   scalars?: SCLR | ScalarCoders;
 };

--- a/examples/typescript-node/src/zeus/index.ts
+++ b/examples/typescript-node/src/zeus/index.ts
@@ -168,7 +168,7 @@ export const Thunder =
   ) =>
   <Z extends ValueTypes[R]>(
     o:
-      | (ValueTypes[R] & (typeof Ops)[O])
+      | (typeof Ops)[O]
       | {
           [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
         },

--- a/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
@@ -127,7 +127,7 @@ export const Thunder =
   ) =>
   <Z extends ValueTypes[R]>(
     o:
-      | (ValueTypes[R] & (typeof Ops)[O])
+      | (typeof Ops)[O]
       | {
           [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
         },

--- a/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/generated.ts
@@ -126,9 +126,11 @@ export const Thunder =
     graphqlOptions?: ThunderGraphQLOptions<OVERRIDESCLR>,
   ) =>
   <Z extends ValueTypes[R]>(
-    o: Z & {
-      [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
-    },
+    o:
+      | (ValueTypes[R] & (typeof Ops)[O])
+      | {
+          [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
+        },
     ops?: OperationOptions & { variables?: Record<string, unknown> },
   ) => {
     const options = {
@@ -421,7 +423,7 @@ export class GraphQLError extends Error {
     return 'GraphQL Response Error';
   }
 }
-export type GenericOperation<O> = O extends keyof typeof Ops ? typeof Ops[O] : never;
+export type GenericOperation<O> = O extends keyof typeof Ops ? (typeof Ops)[O] : never;
 export type ThunderGraphQLOptions<SCLR extends ScalarDefinition> = {
   scalars?: SCLR | ScalarCoders;
 };

--- a/packages/graphql-zeus-core/TreeToTS/functions/new/clientFunctions.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/new/clientFunctions.ts
@@ -35,7 +35,7 @@ export const Thunder =
   ) =>
   <Z extends ValueTypes[R]>(
     o:
-      | (ValueTypes[R] & (typeof Ops)[O])
+      | (typeof Ops)[O]
       | {
           [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
         },

--- a/packages/graphql-zeus-core/TreeToTS/functions/new/clientFunctions.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/new/clientFunctions.ts
@@ -34,9 +34,11 @@ export const Thunder =
     graphqlOptions?: ThunderGraphQLOptions<OVERRIDESCLR>,
   ) =>
   <Z extends ValueTypes[R]>(
-    o: Z & {
-      [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
-    },
+    o:
+      | (ValueTypes[R] & (typeof Ops)[O])
+      | {
+          [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
+        },
     ops?: OperationOptions & { variables?: Record<string, unknown> },
   ) => {
     const options = {

--- a/packages/graphql-zeus-core/TreeToTS/functions/new/models.ts
+++ b/packages/graphql-zeus-core/TreeToTS/functions/new/models.ts
@@ -80,7 +80,7 @@ export class GraphQLError extends Error {
     return 'GraphQL Response Error';
   }
 }
-export type GenericOperation<O> = O extends keyof typeof Ops ? typeof Ops[O] : never;
+export type GenericOperation<O> = O extends keyof typeof Ops ? (typeof Ops)[O] : never;
 export type ThunderGraphQLOptions<SCLR extends ScalarDefinition> = {
   scalars?: SCLR | ScalarCoders;
 };


### PR DESCRIPTION
This PR introduces stricter input validation for `Chain()` methods in `graphql-zeus-core`. The goal is to improve TypeScript's type safety by enforcing excess property checks on the input object passed to `Chain`.

Previously, Zeus allowed extra fields (e.g., `wrong_key`, `wrong_fielder`) to be silently accepted due to the loose typing strategy that relied on structural types.

```ts
  <Z extends ValueTypes[R]>(
    o: Z & {
      [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
    },
    ops?: OperationOptions & { variables?: Record<string, unknown> },
  ) 

↓
    o: (typeof Ops[O]) | 
         {
            [P in keyof Z]: P extends keyof ValueTypes[R] ? Z[P] : never;
        }
```

This change prevents developers from accidentally passing invalid fields into operations, catching such errors during development.

---

### Motivation

In the current Zeus version, the following code **does not** raise any TypeScript error:

```ts
client('mutation')({
  insert_users_one: [
    {
      object: {
        email: "test@example.com",
        wrong_key_does_not_exist_in_user: "should-not-be-here" // not type-checked
      }
    },
    { id: true, wrong_field: false } // also not type-checked
  ]
});
```

After this patch, TypeScript correctly reports the presence of unexpected keys, making the GraphQL client usage safer and more predictable.

Please look at the screenshot as well:

<img width="763" alt="Screenshot 2025-05-16 at 15 23 31" src="https://github.com/user-attachments/assets/0f5fa1c7-6eb2-4ace-b2e4-9db51ffceda1" />

The screenshot shows a comparison of two GraphQL clients instantiated from different Zeus code generation outputs:

old_client → Generated from unpatched Zeus
new_client → Generated from patched Zeus with strict input typing