### PR TITLE
Use `import type` for type imports

### DIFF
--- a/packages/graphql-zeus/plugins/typedDocumentNode/index.ts
+++ b/packages/graphql-zeus/plugins/typedDocumentNode/index.ts
@@ -1,18 +1,18 @@
 import { ProjectOptions } from '@/config.js';
 
 export const pluginTypedDocumentNode = ({ esModule, node }: Partial<ProjectOptions>) => `/* eslint-disable */
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import ${esModule ? '{ gql }' : 'gql'} from 'graphql-tag';
 import {
-  ValueTypes,
-  GenericOperation,
-  OperationOptions,
-  GraphQLTypes,
-  InputType,
-  ScalarDefinition,
-  ThunderGraphQLOptions,
+  type ValueTypes,
+  type GenericOperation,
+  type OperationOptions,
+  type GraphQLTypes,
+  type InputType,
+  type ScalarDefinition,
+  type ThunderGraphQLOptions,
   Zeus,
-  ExtractVariables,
+  type ExtractVariables,
 } from './${esModule || !!node ? 'index.js' : ''}';
 import { Ops } from './const${esModule || !!node ? '.js' : ''}';
 


### PR DESCRIPTION
Attempting to use typedDocumentNode with SvelteKit, or any project that uses the [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) option, results in an error:

```
[plugin:vite:import-analysis] Failed to resolve entry for package "@graphql-typed-document-node/core".
The package may have incorrect main/module/exports specified in its package.json.
```

Simply [adding `type` to the imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) fixes the problem.