### PR TITLE
docs: fix typo in llms guide

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -58,7 +58,7 @@ type Query{
 	drawCard: Card!
 	drawChangeCard: ChangeCard!
 	"""
-	list All Cards availble<br>
+	list All Cards available<br>
 	"""
 	listCards: [Card!]!
 	myStacks: [CardStack!]


### PR DESCRIPTION
Fixes a small typo in `llms.md`: `availble` → `available`.

This is a documentation-only change.