### PR TITLE
docs: fix typo "availble" -> "available"

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -58,7 +58,7 @@ type Query{
 	drawCard: Card!
 	drawChangeCard: ChangeCard!
 	"""
-	list All Cards availble<br>
+	list All Cards available<br>
 	"""
 	listCards: [Card!]!
 	myStacks: [CardStack!]


### PR DESCRIPTION
Simple documentation typo fix.

## Change
- Fix typo `availble` → `available` in `llms.md`
- Small documentation fix, no functional changes